### PR TITLE
Adding `bench eval ./local-path` to support people writing their own evals

### DIFF
--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -104,7 +104,8 @@ def run_eval(
     benchmarks: Annotated[
         List[str],
         typer.Argument(
-            help="Benchmark(s) to use for evaluation", envvar="BENCH_BENCHMARKS"
+            help="Benchmark(s) to run. Can be a built-in name (e.g. mmlu) or a path to a local eval directory/file containing __metadata__", 
+            envvar="BENCH_BENCHMARKS"
         ),
     ],
     model: Annotated[

--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -104,8 +104,8 @@ def run_eval(
     benchmarks: Annotated[
         List[str],
         typer.Argument(
-            help="Benchmark(s) to run. Can be a built-in name (e.g. mmlu) or a path to a local eval directory/file containing __metadata__", 
-            envvar="BENCH_BENCHMARKS"
+            help="Benchmark(s) to run. Can be a built-in name (e.g. mmlu) or a path to a local eval directory/file containing __metadata__",
+            envvar="BENCH_BENCHMARKS",
         ),
     ],
     model: Annotated[

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -1,8 +1,12 @@
 from functools import lru_cache
 import importlib
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+from types import ModuleType
 from typing import Callable
-
-from openbench.config import get_all_benchmarks
+from openbench.config import get_all_benchmarks, BenchmarkMetadata
 
 
 # Dynamically generate registry from config
@@ -17,28 +21,140 @@ def _generate_task_registry():
 TASK_REGISTRY = _generate_task_registry()
 
 
+def _import_module_from_path(path: Path) -> ModuleType:
+    """
+    Import a .py file or package directory as an anonymous module.
+    """
+    file_path = path
+    if path.is_dir():
+        file_path = path / "__init__.py"
+        if not file_path.exists():
+            raise ValueError(f"{path} is a directory but has no __init__.py")
+
+    mod_name = f"_openbench_dyn_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(mod_name, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create import spec for {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+
+    # For packages, set up proper package structure for relative imports
+    if path.is_dir():
+        module.__package__ = mod_name
+        sys.modules[mod_name] = module
+
+        # Pre-load submodules to support relative imports
+        for submodule_file in path.glob("*.py"):
+            if submodule_file.name != "__init__.py":
+                submodule_name = submodule_file.stem
+                submodule_full_name = f"{mod_name}.{submodule_name}"
+                submodule_spec = importlib.util.spec_from_file_location(
+                    submodule_full_name, str(submodule_file)
+                )
+                if submodule_spec and submodule_spec.loader:
+                    submodule = importlib.util.module_from_spec(submodule_spec)
+                    submodule.__package__ = mod_name
+                    sys.modules[submodule_full_name] = submodule
+                    submodule_spec.loader.exec_module(submodule)
+    else:
+        sys.modules[mod_name] = module
+
+    spec.loader.exec_module(module)
+    return module
+
+
 @lru_cache()
 def load_task(benchmark_name: str) -> Callable:
     """
-    Loads a task by benchmark name using the registry.
+    Loads a task by benchmark name using the registry or from a local path.
 
     Args:
-        benchmark_name (str): The name of the benchmark.
+        benchmark_name (str): The name of the benchmark or path to a local eval.
 
     Returns:
         Callable: The imported function object.
 
     Raises:
-        ValueError: If the benchmark is not in the registry.
+        ValueError: If the benchmark is not in the registry and not a valid path.
         ImportError: If the module cannot be imported.
         AttributeError: If the function does not exist in the module.
     """
+    # Try registry first (registry names take precedence)
     import_path = TASK_REGISTRY.get(benchmark_name)
-    if not import_path:
-        raise ValueError(
-            f"Unknown benchmark: '{benchmark_name}'. "
-            f"Available benchmarks: {', '.join(TASK_REGISTRY.keys())}"
+    if import_path:
+        module_path, func_name = import_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        return getattr(module, func_name)
+    
+    # Fallback to path-based loading
+    path = Path(benchmark_name).expanduser()
+    if path.exists():
+        return _load_task_from_local_path(path)
+    
+    # Neither registry nor valid path
+    raise ValueError(
+        f"Unknown benchmark: '{benchmark_name}'. "
+        f"Available benchmarks: {', '.join(TASK_REGISTRY.keys())}"
+    )
+
+
+def _load_task_from_local_path(path: Path) -> Callable:
+    """
+    Load a task from a local path containing __metadata__.
+    
+    Args:
+        path: Path to a directory or .py file containing an eval
+        
+    Returns:
+        Callable: The imported function object
+        
+    Raises:
+        ValueError: If no valid __metadata__ is found
+        AttributeError: If the function does not exist in the module
+        ImportError: If the module cannot be imported
+    """
+    root_module = _import_module_from_path(path)
+    metadata = getattr(root_module, "__metadata__", None)
+    
+    if not isinstance(metadata, BenchmarkMetadata):
+        raise ValueError(f"{path} has no valid __metadata__")
+    
+    # Resolve module path relative to root module
+    # For local evals, module_path is typically relative like "simpleqa.simpleqa"
+    # We need to extract just the last part and combine with the root module name
+    if metadata.module_path.startswith(root_module.__name__):
+        full_module_name = metadata.module_path
+    else:
+        # For paths like "simpleqa.simpleqa", we want the last component "simpleqa"
+        module_components = metadata.module_path.split('.')
+        module_name = module_components[-1]  # Take the last component
+        full_module_name = f"{root_module.__name__}.{module_name}"
+    
+    try:
+        module = importlib.import_module(full_module_name)
+    except ImportError as e:
+        raise ImportError(f"Cannot import module '{full_module_name}': {e}")
+    
+    try:
+        return getattr(module, metadata.function_name)
+    except AttributeError:
+        raise AttributeError(
+            f"Function '{metadata.function_name}' not found in module '{full_module_name}'"
         )
-    module_path, func_name = import_path.rsplit(".", 1)
-    module = importlib.import_module(module_path)
-    return getattr(module, func_name)
+
+
+def get_eval_metadata(path_like: str) -> BenchmarkMetadata | None:
+    """
+    Best-effort extraction of __metadata__ for path-based evals.
+    Returns None for registry-based benchmarks or when no metadata is present.
+    """
+    p = Path(path_like).expanduser()
+    if not p.exists():
+        return None
+
+    try:
+        module = _import_module_from_path(p)
+        meta = getattr(module, "__metadata__", None)
+        return meta if isinstance(meta, BenchmarkMetadata) else None
+    except Exception:
+        return None

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -85,12 +85,12 @@ def load_task(benchmark_name: str) -> Callable:
         module_path, func_name = import_path.rsplit(".", 1)
         module = importlib.import_module(module_path)
         return getattr(module, func_name)
-    
+
     # Fallback to path-based loading
     path = Path(benchmark_name).expanduser()
     if path.exists():
         return _load_task_from_local_path(path)
-    
+
     # Neither registry nor valid path
     raise ValueError(
         f"Unknown benchmark: '{benchmark_name}'. "
@@ -101,13 +101,13 @@ def load_task(benchmark_name: str) -> Callable:
 def _load_task_from_local_path(path: Path) -> Callable:
     """
     Load a task from a local path containing __metadata__.
-    
+
     Args:
         path: Path to a directory or .py file containing an eval
-        
+
     Returns:
         Callable: The imported function object
-        
+
     Raises:
         ValueError: If no valid __metadata__ is found
         AttributeError: If the function does not exist in the module
@@ -115,10 +115,10 @@ def _load_task_from_local_path(path: Path) -> Callable:
     """
     root_module = _import_module_from_path(path)
     metadata = getattr(root_module, "__metadata__", None)
-    
+
     if not isinstance(metadata, BenchmarkMetadata):
         raise ValueError(f"{path} has no valid __metadata__")
-    
+
     # Resolve module path relative to root module
     # For local evals, module_path is typically relative like "simpleqa.simpleqa"
     # We need to extract just the last part and combine with the root module name
@@ -126,15 +126,15 @@ def _load_task_from_local_path(path: Path) -> Callable:
         full_module_name = metadata.module_path
     else:
         # For paths like "simpleqa.simpleqa", we want the last component "simpleqa"
-        module_components = metadata.module_path.split('.')
+        module_components = metadata.module_path.split(".")
         module_name = module_components[-1]  # Take the last component
         full_module_name = f"{root_module.__name__}.{module_name}"
-    
+
     try:
         module = importlib.import_module(full_module_name)
     except ImportError as e:
         raise ImportError(f"Cannot import module '{full_module_name}': {e}")
-    
+
     try:
         return getattr(module, metadata.function_name)
     except AttributeError:

--- a/src/openbench/utils/imports.py
+++ b/src/openbench/utils/imports.py
@@ -1,0 +1,22 @@
+"""Utilities for dynamic module imports."""
+
+import os
+import importlib.util
+
+
+def import_module_from_same_dir(caller_file: str, module_name: str):
+    """Import a module from the same directory as the caller file.
+    
+    Args:
+        caller_file: The __file__ attribute of the calling module
+        module_name: Name of the module to import (without .py extension)
+        
+    Returns:
+        The imported module
+    """
+    current_dir = os.path.dirname(caller_file)
+    module_path = os.path.join(current_dir, f"{module_name}.py")
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/src/openbench/utils/imports.py
+++ b/src/openbench/utils/imports.py
@@ -6,17 +6,21 @@ import importlib.util
 
 def import_module_from_same_dir(caller_file: str, module_name: str):
     """Import a module from the same directory as the caller file.
-    
+
     Args:
         caller_file: The __file__ attribute of the calling module
         module_name: Name of the module to import (without .py extension)
-        
+
     Returns:
         The imported module
     """
     current_dir = os.path.dirname(caller_file)
     module_path = os.path.join(current_dir, f"{module_name}.py")
     spec = importlib.util.spec_from_file_location(module_name, module_path)
+
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create import spec for {module_path}")
+
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION
Decided I'd have a crack at refactoring this project to support a design I think would better support my use-case (wanting to work on my own evals without patching `openbench` itself). So I thought I'd start by implementing this:

```
bench eval ./local-path
```

To start, we could implement all the built-in evals e.g. `bench eval xyz` by saying that `xyz` is just an alias to a directory inside `openbench`. That required a bit of moving things around and my python skills are pretty limited, so this might not be right, but I've started by:

* Made an `evals` directory in the root of the project (instead of being within `src/openbench/{datasets,evals,scorers}`)
* Each `eval` exports a `__metadata__` property which captures the stuff that used to be in `src/openbench/config.py`
* The evals themselves are largely unchanged so far (by design, to keep the diff minimal)
* The `gpqa`, `humaneval` and `simpleqa` have all been ported.

The next step is to port the remaining evals, then extract all the common functionality into `src/openbench` (e.g. the few things in `utils` already). I'm, thinking there should be a standard set of scorers but there's probably other things too.

This is all to support the eventual goal of allowing this DX:

```bash
uvx openbench ./my-eval
uvx openbench github:foo/bar
```

So no need to install anything, or to even have the evals locally (but also not limited to the set that ships with openbench itself), which imo strengthens the whole pitch of making "the process of running evals standardised" without becoming the gatekeeper of _which_ evals are available.

Wdyt?