### PR TITLE
feat: add Nebius model provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -27,6 +27,14 @@ def sambanova() -> Type[ModelAPI]:
     return SambaNovaAPI
 
 
+@modelapi(name="nebius")
+def nebius() -> Type[ModelAPI]:
+    """Register Nebius provider."""
+    from .model._providers.nebius import NebiusAPI
+
+    return NebiusAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/nebius.py
+++ b/src/openbench/model/_providers/nebius.py
@@ -1,0 +1,50 @@
+"""Nebius AI provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class NebiusAPI(OpenAICompatibleAPI):
+    """Nebius AI provider - OpenAI-compatible inference.
+
+    Uses OpenAI-compatible API with Nebius Studio endpoints.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("nebius/", "", 1)
+
+        # Set defaults for Nebius
+        base_url = base_url or os.environ.get(
+            "NEBIUS_BASE_URL", "https://api.studio.nebius.com/v1"
+        )
+        api_key = api_key or os.environ.get("NEBIUS_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "Nebius API key not found. Set NEBIUS_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="nebius",
+            service_base_url="https://api.studio.nebius.com/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add Nebius as a new OpenAI-compatible model provider
- Follows the same implementation pattern as Cerebras and SambaNova providers
- Uses Nebius Studio API endpoint at https://api.studio.nebius.com/v1

## Test Plan
- [x] Provider imports successfully
- [x] Code passes all quality checks (ruff format, ruff check, mypy)
- [x] Pre-commit hooks pass