### PR TITLE
feat: add 'openbench' as alternative CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ Repository = "https://github.com/groq/openbench"
 
 [project.scripts]
 bench = "openbench._cli:main"
+openbench = "openbench._cli:main"
 
 [project.entry-points.inspect_ai]
 openbench = "openbench._registry"


### PR DESCRIPTION
## Summary
- Add `openbench` command as an alternative to `bench` command
- Both commands point to the same CLI implementation (`openbench._cli:main`)
- Provides users with flexibility in command naming

## Test Plan
- [x] Installed package in development mode
- [x] Verified `openbench --help` works correctly
- [x] Verified `bench --help` still works correctly
- [x] Both commands show the same CLI interface
- [x] All pre-commit hooks pass