### PR TITLE
feat: add Nous Research model provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -35,6 +35,14 @@ def nebius() -> Type[ModelAPI]:
     return NebiusAPI
 
 
+@modelapi(name="nous")
+def nous() -> Type[ModelAPI]:
+    """Register Nous Research provider."""
+    from .model._providers.nous import NousAPI
+
+    return NousAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/nous.py
+++ b/src/openbench/model/_providers/nous.py
@@ -1,0 +1,50 @@
+"""Nous Research provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class NousAPI(OpenAICompatibleAPI):
+    """Nous Research - Advanced AI inference.
+
+    Uses OpenAI-compatible API with Nous Research endpoints.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("nous/", "", 1)
+
+        # Set defaults for Nous Research
+        base_url = base_url or os.environ.get(
+            "NOUS_BASE_URL", "https://inference-api.nousresearch.com/v1"
+        )
+        api_key = api_key or os.environ.get("NOUS_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "Nous Research API key not found. Set NOUS_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="nous",
+            service_base_url="https://inference-api.nousresearch.com/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add Nous Research as a new OpenAI-compatible model provider
- Uses prefix `nous/` for model names
- API endpoint: https://inference-api.nousresearch.com/v1
- Follows the same implementation pattern as other OpenAI-compatible providers

## Test Plan
- [x] Provider imports successfully
- [x] Code passes all quality checks (ruff format, ruff check, mypy)
- [x] Pre-commit hooks pass