### PR TITLE
fix: remove default sampling parameters from CLI

### DIFF
--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -209,19 +209,19 @@ def run_eval(
         ),
     ] = True,
     temperature: Annotated[
-        float,
+        Optional[float],
         typer.Option(
             help="Model temperature",
             envvar="BENCH_TEMPERATURE",
         ),
-    ] = 0.6,
+    ] = None,
     top_p: Annotated[
-        float,
+        Optional[float],
         typer.Option(
             help="Model top-p",
             envvar="BENCH_TOP_P",
         ),
-    ] = 1.0,
+    ] = None,
     max_tokens: Annotated[
         Optional[int],
         typer.Option(


### PR DESCRIPTION
## Summary
- Remove default values for temperature (0.6) and top_p (1.0) from the eval command CLI
- Make these parameters optional (None by default) to allow benchmarks to use their own defaults

## Motivation
Currently, the CLI sets global default values for sampling parameters that override benchmark-specific defaults. This change allows each benchmark to define its own appropriate defaults without CLI interference.

## Changes
- Changed `temperature` parameter from `float` with default `0.6` to `Optional[float]` with default `None`
- Changed `top_p` parameter from `float` with default `1.0` to `Optional[float]` with default `None`

## Testing
- All unit tests pass
- Pre-commit hooks pass (ruff check, ruff format, mypy)