### PR TITLE
Fix GraphWalks: Split into three separate benchmarks

### DIFF
--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -31,14 +31,30 @@ class BenchmarkMetadata:
 
 # Benchmark metadata - minimal, no duplication
 BENCHMARKS = {
-    # New - graphwalks
+    # Graphwalks benchmarks
     "graphwalks": BenchmarkMetadata(
-        name="Graphwalks",
-        description="Multi Hop Reasoning Long Context Benchmark - operation performance given a graph represented by its edge list",
+        name="GraphWalks",
+        description="Multi-hop reasoning on graphs - both BFS and parent finding tasks",
         category="core",
         tags=["long-context", "graphs", "reasoning"],
         module_path="openbench.evals.graphwalks",
         function_name="graphwalks",
+    ),
+    "graphwalks_bfs": BenchmarkMetadata(
+        name="GraphWalks BFS",
+        description="Multi-hop reasoning on graphs - BFS traversal tasks only",
+        category="core",
+        tags=["long-context", "graphs", "reasoning", "bfs"],
+        module_path="openbench.evals.graphwalks",
+        function_name="graphwalks_bfs",
+    ),
+    "graphwalks_parents": BenchmarkMetadata(
+        name="GraphWalks Parents",
+        description="Multi-hop reasoning on graphs - parent finding tasks only",
+        category="core",
+        tags=["long-context", "graphs", "reasoning", "parents"],
+        module_path="openbench.evals.graphwalks",
+        function_name="graphwalks_parents",
     ),
     # Core benchmarks
     "mmlu": BenchmarkMetadata(

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from inspect_ai import task, Task
-from inspect_ai.model import ChatMessage, GenerateConfig
+from inspect_ai.model import GenerateConfig
 from inspect_ai.solver import generate
 
 from openbench.datasets.graphwalks import get_dataset
@@ -10,11 +10,33 @@ from openbench.scorers.graphwalks import graphwalks_scorer
 
 
 @task
-def graphwalks(split: str = "train", task_type: str = "both") -> Task:
+def graphwalks(split: str = "train") -> Task:
     return Task(
-        dataset=get_dataset(split=split, task_type=task_type),
-        solver=[generate(messages=lambda row: [ChatMessage.user(row.input)])],
+        dataset=get_dataset(split=split, task_type="both"),
+        solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks",
+        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
+    )
+
+
+@task
+def graphwalks_bfs(split: str = "train") -> Task:
+    return Task(
+        dataset=get_dataset(split=split, task_type="bfs"),
+        solver=[generate()],
+        scorer=graphwalks_scorer(),
+        name="graphwalks_bfs",
+        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
+    )
+
+
+@task
+def graphwalks_parents(split: str = "train") -> Task:
+    return Task(
+        dataset=get_dataset(split=split, task_type="parents"),
+        solver=[generate()],
+        scorer=graphwalks_scorer(),
+        name="graphwalks_parents",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
     )


### PR DESCRIPTION
## Summary
- Split GraphWalks into three separate benchmarks to fix the HuggingFace dataset loading issue
- Created `graphwalks`, `graphwalks_bfs`, and `graphwalks_parents` variants
- Cleaned up unnecessary code in the dataset loader

## Changes
- **graphwalks**: Includes both BFS and parent finding tasks (default)
- **graphwalks_bfs**: BFS traversal tasks only
- **graphwalks_parents**: Parent finding tasks only

## Test plan
- [x] Verified all three functions import successfully
- [x] Confirmed benchmarks appear in `bench list`
- [ ] Run evaluation with API key: `bench eval graphwalks_bfs --model openai/gpt-4o-mini`