### PR TITLE
feat: add Hyperbolic inference provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -59,6 +59,14 @@ def baseten() -> Type[ModelAPI]:
     return BasetenAPI
 
 
+@modelapi(name="hyperbolic")
+def hyperbolic() -> Type[ModelAPI]:
+    """Register Hyperbolic provider."""
+    from .model._providers.hyperbolic import HyperbolicAPI
+
+    return HyperbolicAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/hyperbolic.py
+++ b/src/openbench/model/_providers/hyperbolic.py
@@ -1,0 +1,50 @@
+"""Hyperbolic AI provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class HyperbolicAPI(OpenAICompatibleAPI):
+    """Hyperbolic AI provider - OpenAI-compatible inference.
+
+    Uses OpenAI-compatible API with Hyperbolic-specific configuration.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("hyperbolic/", "", 1)
+
+        # Set defaults for Hyperbolic
+        base_url = base_url or os.environ.get(
+            "HYPERBOLIC_BASE_URL", "https://api.hyperbolic.xyz/v1"
+        )
+        api_key = api_key or os.environ.get("HYPERBOLIC_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "Hyperbolic API key not found. Set HYPERBOLIC_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="hyperbolic",
+            service_base_url="https://api.hyperbolic.xyz/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add support for Hyperbolic as a new inference provider in OpenBench
- Implement OpenAI-compatible API interface for seamless integration
- Enable usage with `hyperbolic/` model prefix

## Implementation Details
- Created `HyperbolicAPI` class extending `OpenAICompatibleAPI`
- Registered provider in `_registry.py` for automatic model routing
- Support for environment variables: `HYPERBOLIC_API_KEY` and `HYPERBOLIC_BASE_URL`
- Default base URL: `https://api.hyperbolic.xyz/v1`

## Testing
- [x] Pre-commit hooks pass (ruff check, ruff format, mypy)
- [x] Code follows existing patterns (based on Cerebras implementation)

## Usage Example
```bash
export HYPERBOLIC_API_KEY=your_key
bench eval mmlu --model hyperbolic/your-model-name --limit 10
```