### PR TITLE
feat: add DeepInfra inference provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -99,6 +99,14 @@ def crusoe() -> Type[ModelAPI]:
     return CrusoeAPI
 
 
+@modelapi(name="deepinfra")
+def deepinfra() -> Type[ModelAPI]:
+    """Register DeepInfra provider."""
+    from .model._providers.deepinfra import DeepInfraAPI
+
+    return DeepInfraAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/deepinfra.py
+++ b/src/openbench/model/_providers/deepinfra.py
@@ -1,0 +1,50 @@
+"""DeepInfra AI provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class DeepInfraAPI(OpenAICompatibleAPI):
+    """DeepInfra AI provider - scalable inference infrastructure.
+
+    Uses OpenAI-compatible API with DeepInfra-specific optimizations.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("deepinfra/", "", 1)
+
+        # Set defaults for DeepInfra
+        base_url = base_url or os.environ.get(
+            "DEEPINFRA_BASE_URL", "https://api.deepinfra.com/v1/openai"
+        )
+        api_key = api_key or os.environ.get("DEEPINFRA_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "DeepInfra API key not found. Set DEEPINFRA_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="deepinfra",
+            service_base_url="https://api.deepinfra.com/v1/openai",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add support for DeepInfra scalable inference infrastructure
- Implements OpenAI-compatible API interface
- Uses DEEPINFRA_API_KEY environment variable for authentication

## Test plan
- [ ] Provider registration works correctly
- [ ] API key validation functions as expected
- [ ] Model name handling preserves compatibility