### PR TITLE
feat: add MiniMax inference provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -115,6 +115,14 @@ def ai21() -> Type[ModelAPI]:
     return AI21API
 
 
+@modelapi(name="minimax")
+def minimax() -> Type[ModelAPI]:
+    """Register MiniMax provider."""
+    from .model._providers.minimax import MiniMaxAPI
+
+    return MiniMaxAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/minimax.py
+++ b/src/openbench/model/_providers/minimax.py
@@ -1,0 +1,50 @@
+"""MiniMax provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class MiniMaxAPI(OpenAICompatibleAPI):
+    """MiniMax provider - AI model infrastructure.
+
+    Uses OpenAI-compatible API with MiniMax-specific optimizations.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("minimax/", "", 1)
+
+        # Set defaults for MiniMax
+        base_url = base_url or os.environ.get(
+            "MINIMAX_BASE_URL", "https://api.minimax.io/v1"
+        )
+        api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "MiniMax API key not found. Set MINIMAX_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="minimax",
+            service_base_url="https://api.minimax.io/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add support for MiniMax AI model infrastructure
- Implements OpenAI-compatible API interface
- Uses MINIMAX_API_KEY environment variable for authentication

## Test plan
- [ ] Provider registration works correctly
- [ ] API key validation functions as expected
- [ ] Model name handling preserves compatibility