### PR TITLE
feat: add Moonshot inference provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -147,6 +147,14 @@ def cohere() -> Type[ModelAPI]:
     return CohereAPI
 
 
+@modelapi(name="moonshot")
+def moonshot() -> Type[ModelAPI]:
+    """Register Moonshot provider."""
+    from .model._providers.moonshot import MoonshotAPI
+
+    return MoonshotAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/moonshot.py
+++ b/src/openbench/model/_providers/moonshot.py
@@ -1,0 +1,50 @@
+"""Moonshot provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class MoonshotAPI(OpenAICompatibleAPI):
+    """Moonshot provider - AI language model infrastructure.
+
+    Uses OpenAI-compatible API with Moonshot-specific optimizations.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("moonshot/", "", 1)
+
+        # Set defaults for Moonshot
+        base_url = base_url or os.environ.get(
+            "MOONSHOT_BASE_URL", "https://api.moonshot.ai/v1"
+        )
+        api_key = api_key or os.environ.get("MOONSHOT_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "Moonshot API key not found. Set MOONSHOT_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="moonshot",
+            service_base_url="https://api.moonshot.ai/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## Summary
- Add support for Moonshot AI language model infrastructure
- Implements OpenAI-compatible API interface  
- Uses MOONSHOT_API_KEY environment variable for authentication

## Test plan
- [ ] Provider registration works correctly
- [ ] API key validation functions as expected
- [ ] Model name handling preserves compatibility