### PR TITLE
feat: add CTI-Bench cybersecurity benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Here are the currently available benchmarks. For an up-to-date list use `bench l
 | **Reasoning** | SimpleQA (factuality), MuSR (multi-step reasoning), DROP (discrete reasoning over paragraphs) |
 | **Long Context** | OpenAI MRCR (multiple needle retrieval), OpenAI MRCR_2n (2 needle), OpenAI MRCR_4 (4 needle), OpenAI MRCR_8n (8 needle) |
 | **Healthcare** | HealthBench (open-ended healthcare eval), HealthBench_hard (challenging variant), HealthBench_consensus (consensus variant) |
+| **Cybersecurity** | CTI-Bench (complete cyber threat intelligence suite), CTI-Bench ATE (MITRE ATT&CK technique extraction), CTI-Bench MCQ (knowledge questions on CTI standards and best practices), CTI-Bench RCM (CVE to CWE vulnerability mapping), CTI-Bench TAA (threat actor attribution), CTI-Bench VSP (CVSS score calculation) |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Here are the currently available benchmarks. For an up-to-date list use `bench l
 | **Reasoning** | SimpleQA (factuality), MuSR (multi-step reasoning), DROP (discrete reasoning over paragraphs) |
 | **Long Context** | OpenAI MRCR (multiple needle retrieval), OpenAI MRCR_2n (2 needle), OpenAI MRCR_4 (4 needle), OpenAI MRCR_8n (8 needle) |
 | **Healthcare** | HealthBench (open-ended healthcare eval), HealthBench_hard (challenging variant), HealthBench_consensus (consensus variant) |
-| **Cybersecurity** | CTI-Bench (complete cyber threat intelligence suite), CTI-Bench ATE (MITRE ATT&CK technique extraction), CTI-Bench MCQ (knowledge questions on CTI standards and best practices), CTI-Bench RCM (CVE to CWE vulnerability mapping), CTI-Bench TAA (threat actor attribution), CTI-Bench VSP (CVSS score calculation) |
+| **Cybersecurity** | CTI-Bench (complete cyber threat intelligence suite), CTI-Bench ATE (MITRE ATT&CK technique extraction), CTI-Bench MCQ (knowledge questions on CTI standards and best practices), CTI-Bench RCM (CVE to CWE vulnerability mapping), CTI-Bench VSP (CVSS score calculation) |
 
 ## Configuration
 

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -364,6 +364,55 @@ BENCHMARKS = {
         function_name="scicode",
         is_alpha=True,
     ),
+    # Cybersecurity benchmarks
+    "cti_bench": BenchmarkMetadata(
+        name="CTI-Bench",
+        description="Comprehensive evaluation framework for cyber threat intelligence understanding, covering CTI standards, threats, detection strategies, and mitigation plans",
+        category="cybersecurity",
+        tags=["cybersecurity", "multi-task"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench",
+    ),
+    "cti_bench_ate": BenchmarkMetadata(
+        name="CTI-Bench ATE",
+        description="Extracting MITRE ATT&CK techniques from malware and threat descriptions",
+        category="cybersecurity",
+        tags=["extraction", "cybersecurity"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench_ate",
+    ),
+    "cti_bench_mcq": BenchmarkMetadata(
+        name="CTI-Bench MCQ",
+        description="Multiple-choice questions evaluating understanding of CTI standards, threats, detection strategies, and best practices using authoritative sources like NIST and MITRE",
+        category="cybersecurity",
+        tags=["multiple-choice", "cybersecurity", "knowledge"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench_mcq",
+    ),
+    "cti_bench_rcm": BenchmarkMetadata(
+        name="CTI-Bench RCM",
+        description="Mapping CVE descriptions to CWE categories to evaluate vulnerability classification ability",
+        category="cybersecurity",
+        tags=["classification", "cybersecurity"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench_rcm",
+    ),
+    "cti_bench_taa": BenchmarkMetadata(
+        name="CTI-Bench TAA",
+        description="Analyzing threat reports to attribute attacks to specific threat actors or malware families",
+        category="cybersecurity",
+        tags=["classification", "cybersecurity"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench_taa",
+    ),
+    "cti_bench_vsp": BenchmarkMetadata(
+        name="CTI-Bench VSP",
+        description="Calculating CVSS scores from vulnerability descriptions to assess severity evaluation skills",
+        category="cybersecurity",
+        tags=["regression", "cybersecurity"],
+        module_path="openbench.evals.cti_bench",
+        function_name="cti_bench_vsp",
+    ),
 }
 
 

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -367,7 +367,7 @@ BENCHMARKS = {
     # Cybersecurity benchmarks
     "cti_bench": BenchmarkMetadata(
         name="CTI-Bench",
-        description="Comprehensive evaluation framework for cyber threat intelligence understanding, covering CTI standards, threats, detection strategies, and mitigation plans",
+        description="Comprehensive evaluation framework for cyber threat intelligence understanding with 4 tasks: knowledge questions, vulnerability classification, CVSS scoring, and technique extraction",
         category="cybersecurity",
         tags=["cybersecurity", "multi-task"],
         module_path="openbench.evals.cti_bench",
@@ -396,14 +396,6 @@ BENCHMARKS = {
         tags=["classification", "cybersecurity"],
         module_path="openbench.evals.cti_bench",
         function_name="cti_bench_rcm",
-    ),
-    "cti_bench_taa": BenchmarkMetadata(
-        name="CTI-Bench TAA",
-        description="Analyzing threat reports to attribute attacks to specific threat actors or malware families",
-        category="cybersecurity",
-        tags=["classification", "cybersecurity"],
-        module_path="openbench.evals.cti_bench",
-        function_name="cti_bench_taa",
     ),
     "cti_bench_vsp": BenchmarkMetadata(
         name="CTI-Bench VSP",

--- a/src/openbench/datasets/cti_bench.py
+++ b/src/openbench/datasets/cti_bench.py
@@ -1,0 +1,204 @@
+"""CTI-Bench dataset loaders for cybersecurity threat intelligence benchmarks."""
+
+from typing import Any, Dict
+from inspect_ai.dataset import Dataset, Sample, hf_dataset
+
+
+def mcq_record_to_sample(record: Dict[str, Any]) -> Sample:
+    """Convert MCQ record to Sample format."""
+    question = record["Question"]
+    
+    # Format options as A) ... B) ... C) ... D) ...
+    formatted_options = [
+        f"{chr(65 + i)}) {record[f'Option {chr(65 + i)}']}"
+        for i in range(4)  # A, B, C, D
+    ]
+    
+    prompt = f"{question}\n\n" + "\n".join(formatted_options) + "\n\nAnswer:"
+    
+    return Sample(
+        input=prompt,
+        target=record["GT"],
+        metadata={
+            "question_type": "multiple_choice",
+            "domain": "cybersecurity",
+            "url": record.get("URL", ""),
+        }
+    )
+
+
+def rcm_record_to_sample(record: Dict[str, Any]) -> Sample:
+    """Convert RCM (CVE→CWE mapping) record to Sample format."""
+    description = record["Description"]
+    
+    prompt = f"""Given the following vulnerability description, identify the most appropriate CWE (Common Weakness Enumeration) category.
+
+Description: {description}
+
+Respond with only the CWE ID (e.g., CWE-79):"""
+    
+    return Sample(
+        input=prompt,
+        target=record["GT"],
+        metadata={
+            "task_type": "classification",
+            "domain": "vulnerability_mapping",
+            "url": record.get("URL", ""),
+        }
+    )
+
+
+def vsp_record_to_sample(record: Dict[str, Any]) -> Sample:
+    """Convert VSP (CVSS severity prediction) record to Sample format."""
+    description = record["Description"]
+    
+    prompt = f"""Given the following vulnerability description, predict the CVSS (Common Vulnerability Scoring System) base score.
+
+Description: {description}
+
+The CVSS base score ranges from 0.0 to 10.0, where:
+- 0.1-3.9: Low severity
+- 4.0-6.9: Medium severity  
+- 7.0-8.9: High severity
+- 9.0-10.0: Critical severity
+
+Respond with only the numeric CVSS score (e.g., 7.5):"""
+    
+    return Sample(
+        input=prompt,
+        target=record["GT"],
+        metadata={
+            "task_type": "regression",
+            "domain": "vulnerability_scoring",
+            "url": record.get("URL", ""),
+        }
+    )
+
+
+def taa_record_to_sample(record: Dict[str, Any]) -> Sample:
+    """Convert TAA (Threat Actor Attribution) record to Sample format."""
+    # Use the dataset's prompt directly
+    prompt = record["Prompt"]
+    
+    # The TAA dataset doesn't have explicit ground truth labels.
+    # We'll try to extract potential threat actors from the full text
+    # and use that as aliases for evaluation.
+    text = record["Text"]
+    url = record.get("URL", "")
+    
+    # Extract potential threat actor names from various sources
+    potential_actors = []
+    aliases = []
+    
+    # Try to extract from URL (like "stately-taurus", "blind-eagle-apt")
+    if url:
+        # Handle URLs that end with '/' by taking the second-to-last part
+        url_filename = url.rstrip('/').split('/')[-1].replace('.html', '')
+        if not url_filename:  # If filename is empty, try the previous part
+            url_filename = url.rstrip('/').split('/')[-2] if len(url.rstrip('/').split('/')) > 1 else ''
+        url_parts = url_filename.split('-')
+        
+        # Look for patterns like "stately-taurus", "blind-eagle", etc.
+        for i in range(len(url_parts)-1):
+            candidate = '-'.join(url_parts[i:i+2])
+            if len(candidate) > 5 and not candidate.isdigit() and not any(word in candidate.lower() for word in ['targets', 'attacks', 'analysis', 'malware', 'threat', 'part']):
+                potential_actors.append(candidate.replace('-', ' ').title())
+        
+        # Also check for single-word threat actors in URL
+        for part in url_parts:
+            if len(part) > 4 and part.lower() not in ['www', 'blog', 'threat', 'research', 'analysis', 'malware', 'part', 'that', 'keeps', 'with', 'from', 'into', 'targets']:
+                # Check if it might be a threat actor name (starts with capital or is all caps)
+                if part[0].isupper() or part.isupper():
+                    potential_actors.append(part.title())
+    
+    # Extract APT groups and threat group names from text
+    import re
+    apt_matches = re.findall(r'APT\d+|APT\s+\d+', text)
+    threat_groups = re.findall(r'[A-Z][a-zA-Z\s]+(?:Group|Tribe|Team|Panda|Bear|Kitten)', text)
+    
+    potential_actors.extend(apt_matches)
+    potential_actors.extend([name.strip() for name in threat_groups])
+    
+    # Use the first potential actor as target, or "Unknown" if none found
+    target = potential_actors[0] if potential_actors else "Unknown"
+    aliases = list(set(potential_actors))  # Remove duplicates
+    
+    return Sample(
+        input=prompt,
+        target=target,
+        metadata={
+            "task_type": "classification",
+            "domain": "threat_attribution", 
+            "url": url,
+            "full_text": text,
+            "aliases": aliases,
+            "extracted_from": "heuristic" if target != "Unknown" else "none",
+        }
+    )
+
+
+def ate_record_to_sample(record: Dict[str, Any]) -> Sample:
+    """Convert ATE (ATT&CK Technique Extraction) record to Sample format."""
+    prompt = record["Prompt"]
+    
+    return Sample(
+        input=prompt,
+        target=record["GT"],
+        metadata={
+            "task_type": "technique_extraction",
+            "domain": "mitre_attack",
+            "url": record.get("URL", ""),
+            "platform": record.get("Platform", ""),
+            "description": record.get("Description", ""),
+        }
+    )
+
+
+def get_cti_bench_mcq_dataset() -> Dataset:
+    """Load CTI-Bench MCQ dataset."""
+    return hf_dataset(
+        path="AI4Sec/cti-bench",
+        name="cti-mcq",
+        split="test",
+        sample_fields=mcq_record_to_sample,
+    )
+
+
+def get_cti_bench_rcm_dataset() -> Dataset:
+    """Load CTI-Bench RCM dataset."""
+    return hf_dataset(
+        path="AI4Sec/cti-bench",
+        name="cti-rcm", 
+        split="test",
+        sample_fields=rcm_record_to_sample,
+    )
+
+
+def get_cti_bench_vsp_dataset() -> Dataset:
+    """Load CTI-Bench VSP dataset."""
+    return hf_dataset(
+        path="AI4Sec/cti-bench",
+        name="cti-vsp",
+        split="test",
+        sample_fields=vsp_record_to_sample,
+    )
+
+
+def get_cti_bench_taa_dataset() -> Dataset:
+    """Load CTI-Bench TAA dataset.""" 
+    return hf_dataset(
+        path="AI4Sec/cti-bench",
+        name="cti-taa",
+        split="test",
+        sample_fields=taa_record_to_sample,
+    )
+
+
+def get_cti_bench_ate_dataset() -> Dataset:
+    """Load CTI-Bench ATE (ATT&CK Technique Extraction) dataset."""
+    return hf_dataset(
+        path="AI4Sec/cti-bench",
+        name="cti-ate",
+        split="test",
+        sample_fields=ate_record_to_sample,
+    )

--- a/src/openbench/datasets/cti_bench.py
+++ b/src/openbench/datasets/cti_bench.py
@@ -7,15 +7,15 @@ from inspect_ai.dataset import Dataset, Sample, hf_dataset
 def mcq_record_to_sample(record: Dict[str, Any]) -> Sample:
     """Convert MCQ record to Sample format."""
     question = record["Question"]
-    
+
     # Format options as A) ... B) ... C) ... D) ...
     formatted_options = [
         f"{chr(65 + i)}) {record[f'Option {chr(65 + i)}']}"
         for i in range(4)  # A, B, C, D
     ]
-    
+
     prompt = f"{question}\n\n" + "\n".join(formatted_options) + "\n\nAnswer:"
-    
+
     return Sample(
         input=prompt,
         target=record["GT"],
@@ -23,20 +23,20 @@ def mcq_record_to_sample(record: Dict[str, Any]) -> Sample:
             "question_type": "multiple_choice",
             "domain": "cybersecurity",
             "url": record.get("URL", ""),
-        }
+        },
     )
 
 
 def rcm_record_to_sample(record: Dict[str, Any]) -> Sample:
     """Convert RCM (CVE→CWE mapping) record to Sample format."""
     description = record["Description"]
-    
+
     prompt = f"""Given the following vulnerability description, identify the most appropriate CWE (Common Weakness Enumeration) category.
 
 Description: {description}
 
 Respond with only the CWE ID (e.g., CWE-79):"""
-    
+
     return Sample(
         input=prompt,
         target=record["GT"],
@@ -44,14 +44,14 @@ Respond with only the CWE ID (e.g., CWE-79):"""
             "task_type": "classification",
             "domain": "vulnerability_mapping",
             "url": record.get("URL", ""),
-        }
+        },
     )
 
 
 def vsp_record_to_sample(record: Dict[str, Any]) -> Sample:
     """Convert VSP (CVSS severity prediction) record to Sample format."""
     description = record["Description"]
-    
+
     prompt = f"""Given the following vulnerability description, predict the CVSS (Common Vulnerability Scoring System) base score.
 
 Description: {description}
@@ -63,7 +63,7 @@ The CVSS base score ranges from 0.0 to 10.0, where:
 - 9.0-10.0: Critical severity
 
 Respond with only the numeric CVSS score (e.g., 7.5):"""
-    
+
     return Sample(
         input=prompt,
         target=record["GT"],
@@ -71,76 +71,14 @@ Respond with only the numeric CVSS score (e.g., 7.5):"""
             "task_type": "regression",
             "domain": "vulnerability_scoring",
             "url": record.get("URL", ""),
-        }
-    )
-
-
-def taa_record_to_sample(record: Dict[str, Any]) -> Sample:
-    """Convert TAA (Threat Actor Attribution) record to Sample format."""
-    # Use the dataset's prompt directly
-    prompt = record["Prompt"]
-    
-    # The TAA dataset doesn't have explicit ground truth labels.
-    # We'll try to extract potential threat actors from the full text
-    # and use that as aliases for evaluation.
-    text = record["Text"]
-    url = record.get("URL", "")
-    
-    # Extract potential threat actor names from various sources
-    potential_actors = []
-    aliases = []
-    
-    # Try to extract from URL (like "stately-taurus", "blind-eagle-apt")
-    if url:
-        # Handle URLs that end with '/' by taking the second-to-last part
-        url_filename = url.rstrip('/').split('/')[-1].replace('.html', '')
-        if not url_filename:  # If filename is empty, try the previous part
-            url_filename = url.rstrip('/').split('/')[-2] if len(url.rstrip('/').split('/')) > 1 else ''
-        url_parts = url_filename.split('-')
-        
-        # Look for patterns like "stately-taurus", "blind-eagle", etc.
-        for i in range(len(url_parts)-1):
-            candidate = '-'.join(url_parts[i:i+2])
-            if len(candidate) > 5 and not candidate.isdigit() and not any(word in candidate.lower() for word in ['targets', 'attacks', 'analysis', 'malware', 'threat', 'part']):
-                potential_actors.append(candidate.replace('-', ' ').title())
-        
-        # Also check for single-word threat actors in URL
-        for part in url_parts:
-            if len(part) > 4 and part.lower() not in ['www', 'blog', 'threat', 'research', 'analysis', 'malware', 'part', 'that', 'keeps', 'with', 'from', 'into', 'targets']:
-                # Check if it might be a threat actor name (starts with capital or is all caps)
-                if part[0].isupper() or part.isupper():
-                    potential_actors.append(part.title())
-    
-    # Extract APT groups and threat group names from text
-    import re
-    apt_matches = re.findall(r'APT\d+|APT\s+\d+', text)
-    threat_groups = re.findall(r'[A-Z][a-zA-Z\s]+(?:Group|Tribe|Team|Panda|Bear|Kitten)', text)
-    
-    potential_actors.extend(apt_matches)
-    potential_actors.extend([name.strip() for name in threat_groups])
-    
-    # Use the first potential actor as target, or "Unknown" if none found
-    target = potential_actors[0] if potential_actors else "Unknown"
-    aliases = list(set(potential_actors))  # Remove duplicates
-    
-    return Sample(
-        input=prompt,
-        target=target,
-        metadata={
-            "task_type": "classification",
-            "domain": "threat_attribution", 
-            "url": url,
-            "full_text": text,
-            "aliases": aliases,
-            "extracted_from": "heuristic" if target != "Unknown" else "none",
-        }
+        },
     )
 
 
 def ate_record_to_sample(record: Dict[str, Any]) -> Sample:
     """Convert ATE (ATT&CK Technique Extraction) record to Sample format."""
     prompt = record["Prompt"]
-    
+
     return Sample(
         input=prompt,
         target=record["GT"],
@@ -150,7 +88,7 @@ def ate_record_to_sample(record: Dict[str, Any]) -> Sample:
             "url": record.get("URL", ""),
             "platform": record.get("Platform", ""),
             "description": record.get("Description", ""),
-        }
+        },
     )
 
 
@@ -168,7 +106,7 @@ def get_cti_bench_rcm_dataset() -> Dataset:
     """Load CTI-Bench RCM dataset."""
     return hf_dataset(
         path="AI4Sec/cti-bench",
-        name="cti-rcm", 
+        name="cti-rcm",
         split="test",
         sample_fields=rcm_record_to_sample,
     )
@@ -181,16 +119,6 @@ def get_cti_bench_vsp_dataset() -> Dataset:
         name="cti-vsp",
         split="test",
         sample_fields=vsp_record_to_sample,
-    )
-
-
-def get_cti_bench_taa_dataset() -> Dataset:
-    """Load CTI-Bench TAA dataset.""" 
-    return hf_dataset(
-        path="AI4Sec/cti-bench",
-        name="cti-taa",
-        split="test",
-        sample_fields=taa_record_to_sample,
     )
 
 

--- a/src/openbench/evals/cti_bench.py
+++ b/src/openbench/evals/cti_bench.py
@@ -1,0 +1,179 @@
+"""CTI-Bench evaluation tasks for cybersecurity threat intelligence benchmarks."""
+
+from inspect_ai import task, Task
+from inspect_ai.solver import generate
+from inspect_ai.model import GenerateConfig
+from inspect_ai.dataset import Dataset, MemoryDataset
+
+from openbench.datasets.cti_bench import (
+    get_cti_bench_mcq_dataset,
+    get_cti_bench_rcm_dataset,
+    get_cti_bench_vsp_dataset,
+    get_cti_bench_taa_dataset,
+    get_cti_bench_ate_dataset,
+)
+from openbench.scorers.cti_bench import (
+    cti_bench_mcq_scorer,
+    cti_bench_rcm_scorer,
+    cti_bench_vsp_scorer,
+    cti_bench_taa_scorer,
+    cti_bench_ate_scorer,
+)
+
+
+@task
+def cti_bench_mcq() -> Task:
+    """CTI-Bench Multiple Choice Questions task."""
+    return Task(
+        dataset=get_cti_bench_mcq_dataset(),
+        solver=[generate()],
+        scorer=cti_bench_mcq_scorer(),
+        name="cti_bench_mcq",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )
+
+
+@task
+def cti_bench_rcm() -> Task:
+    """CTI-Bench RCM (CVE→CWE mapping) task."""
+    return Task(
+        dataset=get_cti_bench_rcm_dataset(),
+        solver=[generate()],
+        scorer=cti_bench_rcm_scorer(),
+        name="cti_bench_rcm",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )
+
+
+@task
+def cti_bench_vsp() -> Task:
+    """CTI-Bench VSP (CVSS severity prediction) task."""
+    return Task(
+        dataset=get_cti_bench_vsp_dataset(),
+        solver=[generate()],
+        scorer=cti_bench_vsp_scorer(),
+        name="cti_bench_vsp",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )
+
+
+@task
+def cti_bench_taa() -> Task:
+    """CTI-Bench TAA (Threat Actor Attribution) task."""
+    return Task(
+        dataset=get_cti_bench_taa_dataset(),
+        solver=[generate()],
+        scorer=cti_bench_taa_scorer(),
+        name="cti_bench_taa",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )
+
+
+@task
+def cti_bench_ate() -> Task:
+    """CTI-Bench ATE (ATT&CK Technique Extraction) task."""
+    return Task(
+        dataset=get_cti_bench_ate_dataset(),
+        solver=[generate()],
+        scorer=cti_bench_ate_scorer(),
+        name="cti_bench_ate",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )
+
+
+def combine_datasets() -> Dataset:
+    """Combine all CTI-Bench datasets into one."""
+    # Load all individual datasets
+    mcq_dataset = get_cti_bench_mcq_dataset()
+    rcm_dataset = get_cti_bench_rcm_dataset()
+    vsp_dataset = get_cti_bench_vsp_dataset()
+    taa_dataset = get_cti_bench_taa_dataset()
+    ate_dataset = get_cti_bench_ate_dataset()
+    
+    combined_samples = []
+    
+    # Add MCQ samples with task type metadata
+    for sample in mcq_dataset:
+        sample.metadata = sample.metadata or {}
+        sample.metadata["task_type"] = "mcq"
+        combined_samples.append(sample)
+    
+    # Add RCM samples with task type metadata
+    for sample in rcm_dataset:
+        sample.metadata = sample.metadata or {}
+        sample.metadata["task_type"] = "rcm"
+        combined_samples.append(sample)
+    
+    # Add VSP samples with task type metadata
+    for sample in vsp_dataset:
+        sample.metadata = sample.metadata or {}
+        sample.metadata["task_type"] = "vsp"
+        combined_samples.append(sample)
+    
+    # Add TAA samples with task type metadata
+    for sample in taa_dataset:
+        sample.metadata = sample.metadata or {}
+        sample.metadata["task_type"] = "taa"
+        combined_samples.append(sample)
+    
+    # Add ATE samples with task type metadata
+    for sample in ate_dataset:
+        sample.metadata = sample.metadata or {}
+        sample.metadata["task_type"] = "ate"
+        combined_samples.append(sample)
+    
+    return MemoryDataset(samples=combined_samples, name="cti_bench")
+
+
+def combined_cti_bench_scorer():
+    """Combined scorer that delegates to appropriate task-specific scorer."""
+    from inspect_ai.scorer import scorer, Score, Target, accuracy, stderr
+    from inspect_ai.solver import TaskState
+    from typing import Callable
+    
+    # Get individual scorers
+    mcq_scorer_fn = cti_bench_mcq_scorer()
+    rcm_scorer_fn = cti_bench_rcm_scorer()
+    vsp_scorer_fn = cti_bench_vsp_scorer()
+    taa_scorer_fn = cti_bench_taa_scorer()
+    ate_scorer_fn = cti_bench_ate_scorer()
+    
+    @scorer(metrics=[accuracy(), stderr()])
+    def cti_bench_combined_scorer() -> Callable:
+        async def score(state: TaskState, target: Target) -> Score:
+            # Determine which scorer to use based on task type
+            task_type = state.metadata.get("task_type") if state.metadata else None
+            
+            if task_type == "mcq":
+                return await mcq_scorer_fn(state, target)
+            elif task_type == "rcm":
+                return await rcm_scorer_fn(state, target)
+            elif task_type == "vsp":
+                return await vsp_scorer_fn(state, target)
+            elif task_type == "taa":
+                return await taa_scorer_fn(state, target)
+            elif task_type == "ate":
+                return await ate_scorer_fn(state, target)
+            else:
+                # Fallback - should not happen
+                return Score(
+                    value=0.0,
+                    answer="",
+                    metadata={"error": f"Unknown task type: {task_type}"}
+                )
+        
+        return score
+    
+    return cti_bench_combined_scorer()
+
+
+@task
+def cti_bench() -> Task:
+    """Combined CTI-Bench evaluation running all 5 cybersecurity tasks."""
+    return Task(
+        dataset=combine_datasets(),
+        solver=[generate()],
+        scorer=combined_cti_bench_scorer(),
+        name="cti_bench",
+        config=GenerateConfig(temperature=0.0, max_tokens=8192),
+    )

--- a/src/openbench/scorers/cti_bench.py
+++ b/src/openbench/scorers/cti_bench.py
@@ -1,7 +1,7 @@
 """CTI-Bench scorers for cybersecurity benchmarking tasks."""
 
 import re
-from typing import Callable, List, Set, Dict, Any
+from typing import Callable, List, Set
 from inspect_ai.scorer import scorer, accuracy, stderr, Score, Target, Metric, metric
 from inspect_ai.solver import TaskState
 from inspect_ai.scorer._metric import SampleScore, Value
@@ -12,32 +12,32 @@ def extract_technique_ids(text: str) -> Set[str]:
     """Extract MITRE ATT&CK technique IDs from model output."""
     if not text:
         return set()
-    
+
     technique_ids = set()
     text_upper = text.upper()
-    
+
     # Single comprehensive pattern for all T-ID formats
     all_patterns = [
-        r'\bT\d{4}(?:\.\d{3})?\b',  # Basic T1234 or T1234.001
-        r'(?:technique\s+)?(T\d{4})(?:\.\d{3})?(?:\s*[:\-,.]|\s|$)',  # Context patterns
+        r"\bT\d{4}(?:\.\d{3})?\b",  # Basic T1234 or T1234.001
+        r"(?:technique\s+)?(T\d{4})(?:\.\d{3})?(?:\s*[:\-,.]|\s|$)",  # Context patterns
     ]
-    
+
     # Extract from all patterns
     for pattern in all_patterns:
         matches = re.findall(pattern, text_upper, re.IGNORECASE)
         for match in matches:
             # Extract main technique ID (remove subtechnique if present)
-            main_technique = match.split('.')[0]
+            main_technique = match.split(".")[0]
             technique_ids.add(main_technique)
-    
+
     # Special handling for final line with only technique IDs
-    lines = text.strip().split('\n')
+    lines = text.strip().split("\n")
     if lines:
         last_line = lines[-1].strip().upper()
-        if re.match(r'^[T\d,\s\.]+$', last_line):
-            final_matches = re.findall(r'T\d{4}(?:\.\d{3})?', last_line)
-            technique_ids.update(match.split('.')[0] for match in final_matches)
-    
+        if re.match(r"^[T\d,\s\.]+$", last_line):
+            final_matches = re.findall(r"T\d{4}(?:\.\d{3})?", last_line)
+            technique_ids.update(match.split(".")[0] for match in final_matches)
+
     return technique_ids
 
 
@@ -45,29 +45,30 @@ def parse_ground_truth(gt_text: str) -> Set[str]:
     """Parse ground truth technique IDs from comma-separated string."""
     if not gt_text:
         return set()
-    
+
     return {
-        technique_id.strip().upper().split('.')[0] 
-        for technique_id in gt_text.split(',') 
-        if technique_id.strip() and technique_id.strip().upper().startswith('T')
+        technique_id.strip().upper().split(".")[0]
+        for technique_id in gt_text.split(",")
+        if technique_id.strip() and technique_id.strip().upper().startswith("T")
     }
 
 
 @metric
 def technique_precision() -> Metric:
     """Calculate precision for technique extraction."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"technique_precision": 0.0}
-        
+
         total_precision = 0.0
         valid_samples = 0
-        
+
         for score in scores:
             metadata = score.score.metadata or {}
             predicted = set(metadata.get("predicted_techniques", []))
             ground_truth = set(metadata.get("ground_truth_techniques", []))
-            
+
             if predicted:
                 precision = len(predicted & ground_truth) / len(predicted)
                 total_precision += precision
@@ -76,31 +77,32 @@ def technique_precision() -> Metric:
                 # If no predictions and no ground truth, count as perfect precision
                 total_precision += 1.0
                 valid_samples += 1
-        
+
         if valid_samples == 0:
             return {"technique_precision": 0.0}
-        
+
         avg_precision = total_precision / valid_samples
         return {"technique_precision": round(avg_precision, 4)}
-    
+
     return metric_fn
 
 
 @metric
 def technique_recall() -> Metric:
     """Calculate recall for technique extraction."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"technique_recall": 0.0}
-        
+
         total_recall = 0.0
         valid_samples = 0
-        
+
         for score in scores:
             metadata = score.score.metadata or {}
             predicted = set(metadata.get("predicted_techniques", []))
             ground_truth = set(metadata.get("ground_truth_techniques", []))
-            
+
             if ground_truth:
                 recall = len(predicted & ground_truth) / len(ground_truth)
                 total_recall += recall
@@ -109,32 +111,33 @@ def technique_recall() -> Metric:
                 # If no ground truth and no predictions, count as perfect recall
                 total_recall += 1.0
                 valid_samples += 1
-        
+
         if valid_samples == 0:
             return {"technique_recall": 0.0}
-        
+
         avg_recall = total_recall / valid_samples
         return {"technique_recall": round(avg_recall, 4)}
-    
+
     return metric_fn
 
 
 @metric
 def technique_f1() -> Metric:
     """Calculate F1 score for technique extraction."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"technique_f1": 0.0}
-        
+
         # Calculate individual precision and recall for each sample
         total_f1 = 0.0
         valid_samples = 0
-        
+
         for score in scores:
             metadata = score.score.metadata or {}
             predicted = set(metadata.get("predicted_techniques", []))
             ground_truth = set(metadata.get("ground_truth_techniques", []))
-            
+
             if not predicted and not ground_truth:
                 # Perfect match when both are empty
                 f1 = 1.0
@@ -146,57 +149,67 @@ def technique_f1() -> Metric:
                 tp = len(predicted & ground_truth)
                 precision = tp / len(predicted) if predicted else 0.0
                 recall = tp / len(ground_truth) if ground_truth else 0.0
-                
+
                 if precision + recall == 0:
                     f1 = 0.0
                 else:
                     f1 = 2 * (precision * recall) / (precision + recall)
-            
+
             total_f1 += f1
             valid_samples += 1
-        
+
         if valid_samples == 0:
             return {"technique_f1": 0.0}
-        
+
         avg_f1 = total_f1 / valid_samples
         return {"technique_f1": round(avg_f1, 4)}
-    
+
     return metric_fn
 
 
 @metric
 def exact_match_accuracy() -> Metric:
     """Calculate exact match accuracy for technique extraction."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"exact_match_accuracy": 0.0}
-        
+
         exact_matches = 0
         for score in scores:
             metadata = score.score.metadata or {}
             predicted = set(metadata.get("predicted_techniques", []))
             ground_truth = set(metadata.get("ground_truth_techniques", []))
-            
+
             if predicted == ground_truth:
                 exact_matches += 1
-        
+
         accuracy = exact_matches / len(scores)
         return {"exact_match_accuracy": round(accuracy, 4)}
-    
+
     return metric_fn
 
 
-@scorer(metrics=[exact_match_accuracy(), technique_precision(), technique_recall(), technique_f1(), stderr()])
+@scorer(
+    metrics=[
+        exact_match_accuracy(),
+        technique_precision(),
+        technique_recall(),
+        technique_f1(),
+        stderr(),
+    ]
+)
 def cti_bench_ate_scorer() -> Callable:
     """Scorer for CTI-Bench ATE (ATT&CK Technique Extraction) task."""
+
     async def score(state: TaskState, target: Target) -> Score:
         # Extract technique IDs from model response
         predicted_techniques = extract_technique_ids(state.output.completion)
         ground_truth_techniques = parse_ground_truth(target.text.strip())
-        
+
         # Calculate exact match
         is_exact_match = predicted_techniques == ground_truth_techniques
-        
+
         # Calculate individual sample metrics for metadata
         if not predicted_techniques and not ground_truth_techniques:
             precision = recall = f1 = 1.0  # Perfect match when both are empty
@@ -205,12 +218,20 @@ def cti_bench_ate_scorer() -> Callable:
         else:
             tp = len(predicted_techniques & ground_truth_techniques)
             precision = tp / len(predicted_techniques) if predicted_techniques else 0.0
-            recall = tp / len(ground_truth_techniques) if ground_truth_techniques else 0.0
-            f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
-        
+            recall = (
+                tp / len(ground_truth_techniques) if ground_truth_techniques else 0.0
+            )
+            f1 = (
+                2 * (precision * recall) / (precision + recall)
+                if (precision + recall) > 0
+                else 0.0
+            )
+
         return Score(
             value=1.0 if is_exact_match else 0.0,
-            answer=", ".join(sorted(predicted_techniques)) if predicted_techniques else "None",
+            answer=", ".join(sorted(predicted_techniques))
+            if predicted_techniques
+            else "None",
             metadata={
                 "predicted_techniques": list(predicted_techniques),
                 "ground_truth_techniques": list(ground_truth_techniques),
@@ -218,8 +239,9 @@ def cti_bench_ate_scorer() -> Callable:
                 "sample_recall": round(recall, 4),
                 "sample_f1": round(f1, 4),
                 "raw_output": state.output.completion,
-            }
+            },
         )
+
     return score
 
 
@@ -228,7 +250,7 @@ def extract_multiple_choice_answer(text: str) -> str:
     """Extract multiple choice answer from model output."""
     if not text:
         return ""
-    
+
     # Try various patterns to extract the answer
     patterns = [
         r"(?:answer|choice|option|select).*?([ABCD])\b",  # "answer is A", "choice B", etc.
@@ -237,31 +259,32 @@ def extract_multiple_choice_answer(text: str) -> str:
         r"^([ABCD])(?:\.|:|\s|$)",  # Answer starts with letter
         r"\b([ABCD])(?:\.|:|\s|$)",  # Letter at word boundary
     ]
-    
+
     for pattern in patterns:
         match = re.search(pattern, text, re.IGNORECASE)
         if match:
             return match.group(1).upper()
-    
+
     # Fallback: look for any A, B, C, or D in the text
-    letters = re.findall(r'[ABCD]', text.upper())
+    letters = re.findall(r"[ABCD]", text.upper())
     if letters:
         return letters[0]
-    
+
     return ""
 
 
 @scorer(metrics=[accuracy(), stderr()])
 def cti_bench_mcq_scorer() -> Callable:
     """Scorer for CTI-Bench multiple choice questions."""
+
     async def score(state: TaskState, target: Target) -> Score:
         # Extract the answer from model response
         extracted_answer = extract_multiple_choice_answer(state.output.completion)
         target_answer = target.text.strip().upper()
-        
+
         # Check if extracted answer matches target
         is_correct = extracted_answer == target_answer
-        
+
         return Score(
             value=1.0 if is_correct else 0.0,
             answer=extracted_answer,
@@ -269,8 +292,9 @@ def cti_bench_mcq_scorer() -> Callable:
                 "extracted_answer": extracted_answer,
                 "target_answer": target_answer,
                 "raw_output": state.output.completion,
-            }
+            },
         )
+
     return score
 
 
@@ -279,40 +303,41 @@ def extract_cwe_id(text: str) -> str:
     """Extract CWE ID from model output."""
     if not text:
         return ""
-    
+
     # Try to find CWE-XXX pattern
     cwe_pattern = r"CWE-(\d+)"
     match = re.search(cwe_pattern, text, re.IGNORECASE)
     if match:
         return f"CWE-{match.group(1)}"
-    
+
     # Try to find just numbers that might be CWE IDs
     number_pattern = r"\b(\d+)\b"
     matches = re.findall(number_pattern, text)
     if matches:
         # Take the first number found
         return f"CWE-{matches[0]}"
-    
+
     return ""
 
 
 @scorer(metrics=[accuracy(), stderr()])
 def cti_bench_rcm_scorer() -> Callable:
     """Scorer for CTI-Bench RCM (CVE→CWE mapping) task."""
+
     async def score(state: TaskState, target: Target) -> Score:
         # Extract CWE ID from model response
         extracted_cwe = extract_cwe_id(state.output.completion)
         target_cwe = target.text.strip()
-        
+
         # Normalize both to ensure consistent format
         if extracted_cwe and not extracted_cwe.startswith("CWE-"):
             extracted_cwe = f"CWE-{extracted_cwe}"
         if target_cwe and not target_cwe.startswith("CWE-"):
             target_cwe = f"CWE-{target_cwe}"
-        
+
         # Check if extracted CWE matches target
         is_correct = extracted_cwe.upper() == target_cwe.upper()
-        
+
         return Score(
             value=1.0 if is_correct else 0.0,
             answer=extracted_cwe,
@@ -320,148 +345,9 @@ def cti_bench_rcm_scorer() -> Callable:
                 "extracted_cwe": extracted_cwe,
                 "target_cwe": target_cwe,
                 "raw_output": state.output.completion,
-            }
+            },
         )
-    return score
 
-
-# TAA (Threat Actor Attribution) Functions
-def normalize_threat_actor_name(name: str) -> str:
-    """Normalize threat actor name for comparison."""
-    if not name:
-        return ""
-    
-    # Convert to lowercase and remove common prefixes/suffixes
-    normalized = name.lower().strip()
-    
-    # Remove common prefixes
-    prefixes_to_remove = ["apt", "group", "team", "operation", "op"]
-    for prefix in prefixes_to_remove:
-        if normalized.startswith(f"{prefix} "):
-            normalized = normalized[len(prefix):].strip()
-        if normalized.startswith(f"{prefix}-"):
-            normalized = normalized[len(prefix):].strip()
-    
-    # Remove special characters and extra spaces
-    normalized = re.sub(r'[^\w\s]', ' ', normalized)
-    normalized = re.sub(r'\s+', ' ', normalized).strip()
-    
-    return normalized
-
-
-def extract_threat_actor(text: str) -> str:
-    """Extract threat actor name from model output."""
-    if not text:
-        return ""
-    
-    lines = text.split('\n')
-    
-    # Look for common patterns in the first few lines
-    for line in lines[:5]:
-        line = line.strip()
-        if not line:
-            continue
-        
-        # Remove common prefixes from the response
-        patterns_to_remove = [
-            r"^(?:this\s+attack\s+was\s+conducted\s+by\s+)",
-            r"^(?:based\s+on.*?this\s+is\s+likely\s+)",
-            r"^(?:the\s+)?(?:threat\s+actor|group|actor)\s+(?:is\s+)?",
-            r"^(?:most\s+likely\s+)?(?:responsible\s+)?(?:is\s+)?",
-            r"^(?:answer\s*:?\s*)",
-            r"^(?:based\s+on.*?,?\s*)",
-        ]
-        
-        for pattern in patterns_to_remove:
-            line = re.sub(pattern, '', line, flags=re.IGNORECASE).strip()
-        
-        if line:
-            return line
-    
-    # Fallback: return the first non-empty line
-    for line in lines:
-        line = line.strip()
-        if line:
-            return line
-    
-    return ""
-
-
-def check_threat_actor_match(predicted: str, target: str, aliases: List[str]) -> bool:
-    """Check if predicted threat actor matches target or aliases."""
-    if not predicted:
-        return False
-    
-    predicted_norm = normalize_threat_actor_name(predicted)
-    target_norm = normalize_threat_actor_name(target)
-    
-    # Direct match with target
-    if predicted_norm == target_norm:
-        return True
-    
-    # Check if predicted contains target or vice versa
-    if predicted_norm in target_norm or target_norm in predicted_norm:
-        return True
-    
-    # Check against aliases
-    for alias in aliases:
-        alias_norm = normalize_threat_actor_name(alias)
-        if predicted_norm == alias_norm:
-            return True
-        if predicted_norm in alias_norm or alias_norm in predicted_norm:
-            return True
-    
-    return False
-
-
-@metric
-def alias_aware_accuracy() -> Metric:
-    """Calculate accuracy considering threat actor aliases."""
-    def metric_fn(scores: List[SampleScore]) -> Value:
-        if not scores:
-            return {"alias_aware_accuracy": 0.0}
-        
-        correct = 0
-        for score in scores:
-            # Handle different value types that SampleScore.value might contain
-            score_value = score.score.value
-            if isinstance(score_value, (int, float)) and score_value > 0:
-                correct += 1
-        
-        accuracy = correct / len(scores)
-        return {"alias_aware_accuracy": round(accuracy, 4)}
-    
-    return metric_fn
-
-
-@scorer(metrics=[alias_aware_accuracy(), stderr()])
-def cti_bench_taa_scorer() -> Callable:
-    """Scorer for CTI-Bench TAA (Threat Actor Attribution) task."""
-    async def score(state: TaskState, target: Target) -> Score:
-        # Extract threat actor from model response
-        predicted_actor = extract_threat_actor(state.output.completion)
-        target_actor = target.text.strip()
-        
-        # Get aliases from sample metadata if available
-        aliases = []
-        if hasattr(state, 'sample') and state.sample and hasattr(state.sample, 'metadata'):
-            aliases = state.sample.metadata.get('aliases', [])
-        
-        # Check if prediction matches target or aliases
-        is_correct = check_threat_actor_match(predicted_actor, target_actor, aliases)
-        
-        return Score(
-            value=1.0 if is_correct else 0.0,
-            answer=predicted_actor,
-            metadata={
-                "predicted_actor": predicted_actor,
-                "target_actor": target_actor,
-                "aliases": aliases,
-                "normalized_predicted": normalize_threat_actor_name(predicted_actor),
-                "normalized_target": normalize_threat_actor_name(target_actor),
-                "raw_output": state.output.completion,
-            }
-        )
     return score
 
 
@@ -470,7 +356,7 @@ def extract_cvss_score(text: str) -> float:
     """Extract CVSS score from model output."""
     if not text:
         return 0.0
-    
+
     # Try to find decimal numbers (CVSS scores)
     decimal_pattern = r"(\d+\.\d+)"
     matches = re.findall(decimal_pattern, text)
@@ -481,7 +367,7 @@ def extract_cvss_score(text: str) -> float:
             return max(0.0, min(10.0, score))
         except ValueError:
             pass
-    
+
     # Try to find integers that might be CVSS scores
     integer_pattern = r"\b(\d+)\b"
     matches = re.findall(integer_pattern, text)
@@ -492,74 +378,77 @@ def extract_cvss_score(text: str) -> float:
             return max(0.0, min(10.0, score))
         except ValueError:
             pass
-    
+
     return 0.0
 
 
 @metric
 def mean_absolute_deviation() -> Metric:
     """Calculate Mean Absolute Deviation for CVSS score predictions."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"mean_absolute_deviation": 0.0}
-        
+
         deviations = []
         for score in scores:
-            if hasattr(score, 'metadata') and score.metadata:
+            if hasattr(score, "metadata") and score.metadata:
                 predicted = score.metadata.get("predicted_score", 0.0)
                 actual = score.metadata.get("actual_score", 0.0)
                 deviation = abs(predicted - actual)
                 deviations.append(deviation)
-        
+
         if not deviations:
             return {"mean_absolute_deviation": 0.0}
-        
+
         mad = sum(deviations) / len(deviations)
         return {"mean_absolute_deviation": round(mad, 4)}
-    
+
     return metric_fn
 
 
 @metric
 def accuracy_within_threshold() -> Metric:
     """Calculate accuracy within 1.0 CVSS point threshold."""
+
     def metric_fn(scores: List[SampleScore]) -> Value:
         if not scores:
             return {"accuracy_within_1_point": 0.0}
-        
+
         correct = 0
         for score in scores:
-            if hasattr(score, 'metadata') and score.metadata:
+            if hasattr(score, "metadata") and score.metadata:
                 predicted = score.metadata.get("predicted_score", 0.0)
                 actual = score.metadata.get("actual_score", 0.0)
                 if abs(predicted - actual) <= 1.0:
                     correct += 1
-        
+
         accuracy = correct / len(scores)
         return {"accuracy_within_1_point": round(accuracy, 4)}
-    
+
     return metric_fn
 
 
 @scorer(metrics=[mean_absolute_deviation(), accuracy_within_threshold(), stderr()])
 def cti_bench_vsp_scorer() -> Callable:
     """Scorer for CTI-Bench VSP (CVSS severity prediction) task."""
+
     async def score(state: TaskState, target: Target) -> Score:
         # Extract CVSS score from model response
         predicted_score = extract_cvss_score(state.output.completion)
-        
+
         try:
             actual_score = float(target.text.strip())
         except ValueError:
             actual_score = 0.0
-        
+
         # Calculate absolute deviation
         absolute_deviation = abs(predicted_score - actual_score)
-        
+
         # Score is inversely related to deviation (lower deviation = higher score)
         # Use a score of 1.0 if deviation is 0, decreasing linearly
         score_value = max(0.0, 1.0 - (absolute_deviation / 10.0))
-        
+
         return Score(
             value=score_value,
             answer=str(predicted_score),
@@ -568,6 +457,7 @@ def cti_bench_vsp_scorer() -> Callable:
                 "actual_score": actual_score,
                 "absolute_deviation": absolute_deviation,
                 "raw_output": state.output.completion,
-            }
+            },
         )
+
     return score

--- a/src/openbench/scorers/cti_bench.py
+++ b/src/openbench/scorers/cti_bench.py
@@ -1,0 +1,573 @@
+"""CTI-Bench scorers for cybersecurity benchmarking tasks."""
+
+import re
+from typing import Callable, List, Set, Dict, Any
+from inspect_ai.scorer import scorer, accuracy, stderr, Score, Target, Metric, metric
+from inspect_ai.solver import TaskState
+from inspect_ai.scorer._metric import SampleScore, Value
+
+
+# ATE (ATT&CK Technique Extraction) Functions
+def extract_technique_ids(text: str) -> Set[str]:
+    """Extract MITRE ATT&CK technique IDs from model output."""
+    if not text:
+        return set()
+    
+    technique_ids = set()
+    text_upper = text.upper()
+    
+    # Single comprehensive pattern for all T-ID formats
+    all_patterns = [
+        r'\bT\d{4}(?:\.\d{3})?\b',  # Basic T1234 or T1234.001
+        r'(?:technique\s+)?(T\d{4})(?:\.\d{3})?(?:\s*[:\-,.]|\s|$)',  # Context patterns
+    ]
+    
+    # Extract from all patterns
+    for pattern in all_patterns:
+        matches = re.findall(pattern, text_upper, re.IGNORECASE)
+        for match in matches:
+            # Extract main technique ID (remove subtechnique if present)
+            main_technique = match.split('.')[0]
+            technique_ids.add(main_technique)
+    
+    # Special handling for final line with only technique IDs
+    lines = text.strip().split('\n')
+    if lines:
+        last_line = lines[-1].strip().upper()
+        if re.match(r'^[T\d,\s\.]+$', last_line):
+            final_matches = re.findall(r'T\d{4}(?:\.\d{3})?', last_line)
+            technique_ids.update(match.split('.')[0] for match in final_matches)
+    
+    return technique_ids
+
+
+def parse_ground_truth(gt_text: str) -> Set[str]:
+    """Parse ground truth technique IDs from comma-separated string."""
+    if not gt_text:
+        return set()
+    
+    return {
+        technique_id.strip().upper().split('.')[0] 
+        for technique_id in gt_text.split(',') 
+        if technique_id.strip() and technique_id.strip().upper().startswith('T')
+    }
+
+
+@metric
+def technique_precision() -> Metric:
+    """Calculate precision for technique extraction."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"technique_precision": 0.0}
+        
+        total_precision = 0.0
+        valid_samples = 0
+        
+        for score in scores:
+            metadata = score.score.metadata or {}
+            predicted = set(metadata.get("predicted_techniques", []))
+            ground_truth = set(metadata.get("ground_truth_techniques", []))
+            
+            if predicted:
+                precision = len(predicted & ground_truth) / len(predicted)
+                total_precision += precision
+                valid_samples += 1
+            elif not ground_truth:
+                # If no predictions and no ground truth, count as perfect precision
+                total_precision += 1.0
+                valid_samples += 1
+        
+        if valid_samples == 0:
+            return {"technique_precision": 0.0}
+        
+        avg_precision = total_precision / valid_samples
+        return {"technique_precision": round(avg_precision, 4)}
+    
+    return metric_fn
+
+
+@metric
+def technique_recall() -> Metric:
+    """Calculate recall for technique extraction."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"technique_recall": 0.0}
+        
+        total_recall = 0.0
+        valid_samples = 0
+        
+        for score in scores:
+            metadata = score.score.metadata or {}
+            predicted = set(metadata.get("predicted_techniques", []))
+            ground_truth = set(metadata.get("ground_truth_techniques", []))
+            
+            if ground_truth:
+                recall = len(predicted & ground_truth) / len(ground_truth)
+                total_recall += recall
+                valid_samples += 1
+            elif not predicted:
+                # If no ground truth and no predictions, count as perfect recall
+                total_recall += 1.0
+                valid_samples += 1
+        
+        if valid_samples == 0:
+            return {"technique_recall": 0.0}
+        
+        avg_recall = total_recall / valid_samples
+        return {"technique_recall": round(avg_recall, 4)}
+    
+    return metric_fn
+
+
+@metric
+def technique_f1() -> Metric:
+    """Calculate F1 score for technique extraction."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"technique_f1": 0.0}
+        
+        # Calculate individual precision and recall for each sample
+        total_f1 = 0.0
+        valid_samples = 0
+        
+        for score in scores:
+            metadata = score.score.metadata or {}
+            predicted = set(metadata.get("predicted_techniques", []))
+            ground_truth = set(metadata.get("ground_truth_techniques", []))
+            
+            if not predicted and not ground_truth:
+                # Perfect match when both are empty
+                f1 = 1.0
+            elif not predicted or not ground_truth:
+                # One is empty, the other is not - F1 is 0
+                f1 = 0.0
+            else:
+                # Both have values, calculate F1
+                tp = len(predicted & ground_truth)
+                precision = tp / len(predicted) if predicted else 0.0
+                recall = tp / len(ground_truth) if ground_truth else 0.0
+                
+                if precision + recall == 0:
+                    f1 = 0.0
+                else:
+                    f1 = 2 * (precision * recall) / (precision + recall)
+            
+            total_f1 += f1
+            valid_samples += 1
+        
+        if valid_samples == 0:
+            return {"technique_f1": 0.0}
+        
+        avg_f1 = total_f1 / valid_samples
+        return {"technique_f1": round(avg_f1, 4)}
+    
+    return metric_fn
+
+
+@metric
+def exact_match_accuracy() -> Metric:
+    """Calculate exact match accuracy for technique extraction."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"exact_match_accuracy": 0.0}
+        
+        exact_matches = 0
+        for score in scores:
+            metadata = score.score.metadata or {}
+            predicted = set(metadata.get("predicted_techniques", []))
+            ground_truth = set(metadata.get("ground_truth_techniques", []))
+            
+            if predicted == ground_truth:
+                exact_matches += 1
+        
+        accuracy = exact_matches / len(scores)
+        return {"exact_match_accuracy": round(accuracy, 4)}
+    
+    return metric_fn
+
+
+@scorer(metrics=[exact_match_accuracy(), technique_precision(), technique_recall(), technique_f1(), stderr()])
+def cti_bench_ate_scorer() -> Callable:
+    """Scorer for CTI-Bench ATE (ATT&CK Technique Extraction) task."""
+    async def score(state: TaskState, target: Target) -> Score:
+        # Extract technique IDs from model response
+        predicted_techniques = extract_technique_ids(state.output.completion)
+        ground_truth_techniques = parse_ground_truth(target.text.strip())
+        
+        # Calculate exact match
+        is_exact_match = predicted_techniques == ground_truth_techniques
+        
+        # Calculate individual sample metrics for metadata
+        if not predicted_techniques and not ground_truth_techniques:
+            precision = recall = f1 = 1.0  # Perfect match when both are empty
+        elif not predicted_techniques or not ground_truth_techniques:
+            precision = recall = f1 = 0.0  # One is empty, the other is not
+        else:
+            tp = len(predicted_techniques & ground_truth_techniques)
+            precision = tp / len(predicted_techniques) if predicted_techniques else 0.0
+            recall = tp / len(ground_truth_techniques) if ground_truth_techniques else 0.0
+            f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
+        
+        return Score(
+            value=1.0 if is_exact_match else 0.0,
+            answer=", ".join(sorted(predicted_techniques)) if predicted_techniques else "None",
+            metadata={
+                "predicted_techniques": list(predicted_techniques),
+                "ground_truth_techniques": list(ground_truth_techniques),
+                "sample_precision": round(precision, 4),
+                "sample_recall": round(recall, 4),
+                "sample_f1": round(f1, 4),
+                "raw_output": state.output.completion,
+            }
+        )
+    return score
+
+
+# MCQ (Multiple Choice Questions) Functions
+def extract_multiple_choice_answer(text: str) -> str:
+    """Extract multiple choice answer from model output."""
+    if not text:
+        return ""
+    
+    # Try various patterns to extract the answer
+    patterns = [
+        r"(?:answer|choice|option|select).*?([ABCD])\b",  # "answer is A", "choice B", etc.
+        r"\b([ABCD])\)",  # "A)", "B)", etc.
+        r"\(([ABCD])\)",  # "(A)", "(B)", etc.
+        r"^([ABCD])(?:\.|:|\s|$)",  # Answer starts with letter
+        r"\b([ABCD])(?:\.|:|\s|$)",  # Letter at word boundary
+    ]
+    
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+    
+    # Fallback: look for any A, B, C, or D in the text
+    letters = re.findall(r'[ABCD]', text.upper())
+    if letters:
+        return letters[0]
+    
+    return ""
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def cti_bench_mcq_scorer() -> Callable:
+    """Scorer for CTI-Bench multiple choice questions."""
+    async def score(state: TaskState, target: Target) -> Score:
+        # Extract the answer from model response
+        extracted_answer = extract_multiple_choice_answer(state.output.completion)
+        target_answer = target.text.strip().upper()
+        
+        # Check if extracted answer matches target
+        is_correct = extracted_answer == target_answer
+        
+        return Score(
+            value=1.0 if is_correct else 0.0,
+            answer=extracted_answer,
+            metadata={
+                "extracted_answer": extracted_answer,
+                "target_answer": target_answer,
+                "raw_output": state.output.completion,
+            }
+        )
+    return score
+
+
+# RCM (CVE→CWE vulnerability mapping) Functions
+def extract_cwe_id(text: str) -> str:
+    """Extract CWE ID from model output."""
+    if not text:
+        return ""
+    
+    # Try to find CWE-XXX pattern
+    cwe_pattern = r"CWE-(\d+)"
+    match = re.search(cwe_pattern, text, re.IGNORECASE)
+    if match:
+        return f"CWE-{match.group(1)}"
+    
+    # Try to find just numbers that might be CWE IDs
+    number_pattern = r"\b(\d+)\b"
+    matches = re.findall(number_pattern, text)
+    if matches:
+        # Take the first number found
+        return f"CWE-{matches[0]}"
+    
+    return ""
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def cti_bench_rcm_scorer() -> Callable:
+    """Scorer for CTI-Bench RCM (CVE→CWE mapping) task."""
+    async def score(state: TaskState, target: Target) -> Score:
+        # Extract CWE ID from model response
+        extracted_cwe = extract_cwe_id(state.output.completion)
+        target_cwe = target.text.strip()
+        
+        # Normalize both to ensure consistent format
+        if extracted_cwe and not extracted_cwe.startswith("CWE-"):
+            extracted_cwe = f"CWE-{extracted_cwe}"
+        if target_cwe and not target_cwe.startswith("CWE-"):
+            target_cwe = f"CWE-{target_cwe}"
+        
+        # Check if extracted CWE matches target
+        is_correct = extracted_cwe.upper() == target_cwe.upper()
+        
+        return Score(
+            value=1.0 if is_correct else 0.0,
+            answer=extracted_cwe,
+            metadata={
+                "extracted_cwe": extracted_cwe,
+                "target_cwe": target_cwe,
+                "raw_output": state.output.completion,
+            }
+        )
+    return score
+
+
+# TAA (Threat Actor Attribution) Functions
+def normalize_threat_actor_name(name: str) -> str:
+    """Normalize threat actor name for comparison."""
+    if not name:
+        return ""
+    
+    # Convert to lowercase and remove common prefixes/suffixes
+    normalized = name.lower().strip()
+    
+    # Remove common prefixes
+    prefixes_to_remove = ["apt", "group", "team", "operation", "op"]
+    for prefix in prefixes_to_remove:
+        if normalized.startswith(f"{prefix} "):
+            normalized = normalized[len(prefix):].strip()
+        if normalized.startswith(f"{prefix}-"):
+            normalized = normalized[len(prefix):].strip()
+    
+    # Remove special characters and extra spaces
+    normalized = re.sub(r'[^\w\s]', ' ', normalized)
+    normalized = re.sub(r'\s+', ' ', normalized).strip()
+    
+    return normalized
+
+
+def extract_threat_actor(text: str) -> str:
+    """Extract threat actor name from model output."""
+    if not text:
+        return ""
+    
+    lines = text.split('\n')
+    
+    # Look for common patterns in the first few lines
+    for line in lines[:5]:
+        line = line.strip()
+        if not line:
+            continue
+        
+        # Remove common prefixes from the response
+        patterns_to_remove = [
+            r"^(?:this\s+attack\s+was\s+conducted\s+by\s+)",
+            r"^(?:based\s+on.*?this\s+is\s+likely\s+)",
+            r"^(?:the\s+)?(?:threat\s+actor|group|actor)\s+(?:is\s+)?",
+            r"^(?:most\s+likely\s+)?(?:responsible\s+)?(?:is\s+)?",
+            r"^(?:answer\s*:?\s*)",
+            r"^(?:based\s+on.*?,?\s*)",
+        ]
+        
+        for pattern in patterns_to_remove:
+            line = re.sub(pattern, '', line, flags=re.IGNORECASE).strip()
+        
+        if line:
+            return line
+    
+    # Fallback: return the first non-empty line
+    for line in lines:
+        line = line.strip()
+        if line:
+            return line
+    
+    return ""
+
+
+def check_threat_actor_match(predicted: str, target: str, aliases: List[str]) -> bool:
+    """Check if predicted threat actor matches target or aliases."""
+    if not predicted:
+        return False
+    
+    predicted_norm = normalize_threat_actor_name(predicted)
+    target_norm = normalize_threat_actor_name(target)
+    
+    # Direct match with target
+    if predicted_norm == target_norm:
+        return True
+    
+    # Check if predicted contains target or vice versa
+    if predicted_norm in target_norm or target_norm in predicted_norm:
+        return True
+    
+    # Check against aliases
+    for alias in aliases:
+        alias_norm = normalize_threat_actor_name(alias)
+        if predicted_norm == alias_norm:
+            return True
+        if predicted_norm in alias_norm or alias_norm in predicted_norm:
+            return True
+    
+    return False
+
+
+@metric
+def alias_aware_accuracy() -> Metric:
+    """Calculate accuracy considering threat actor aliases."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"alias_aware_accuracy": 0.0}
+        
+        correct = 0
+        for score in scores:
+            # Handle different value types that SampleScore.value might contain
+            score_value = score.score.value
+            if isinstance(score_value, (int, float)) and score_value > 0:
+                correct += 1
+        
+        accuracy = correct / len(scores)
+        return {"alias_aware_accuracy": round(accuracy, 4)}
+    
+    return metric_fn
+
+
+@scorer(metrics=[alias_aware_accuracy(), stderr()])
+def cti_bench_taa_scorer() -> Callable:
+    """Scorer for CTI-Bench TAA (Threat Actor Attribution) task."""
+    async def score(state: TaskState, target: Target) -> Score:
+        # Extract threat actor from model response
+        predicted_actor = extract_threat_actor(state.output.completion)
+        target_actor = target.text.strip()
+        
+        # Get aliases from sample metadata if available
+        aliases = []
+        if hasattr(state, 'sample') and state.sample and hasattr(state.sample, 'metadata'):
+            aliases = state.sample.metadata.get('aliases', [])
+        
+        # Check if prediction matches target or aliases
+        is_correct = check_threat_actor_match(predicted_actor, target_actor, aliases)
+        
+        return Score(
+            value=1.0 if is_correct else 0.0,
+            answer=predicted_actor,
+            metadata={
+                "predicted_actor": predicted_actor,
+                "target_actor": target_actor,
+                "aliases": aliases,
+                "normalized_predicted": normalize_threat_actor_name(predicted_actor),
+                "normalized_target": normalize_threat_actor_name(target_actor),
+                "raw_output": state.output.completion,
+            }
+        )
+    return score
+
+
+# VSP (CVSS severity prediction) Functions
+def extract_cvss_score(text: str) -> float:
+    """Extract CVSS score from model output."""
+    if not text:
+        return 0.0
+    
+    # Try to find decimal numbers (CVSS scores)
+    decimal_pattern = r"(\d+\.\d+)"
+    matches = re.findall(decimal_pattern, text)
+    if matches:
+        try:
+            score = float(matches[0])
+            # Clamp to valid CVSS range
+            return max(0.0, min(10.0, score))
+        except ValueError:
+            pass
+    
+    # Try to find integers that might be CVSS scores
+    integer_pattern = r"\b(\d+)\b"
+    matches = re.findall(integer_pattern, text)
+    if matches:
+        try:
+            score = float(matches[0])
+            # Clamp to valid CVSS range
+            return max(0.0, min(10.0, score))
+        except ValueError:
+            pass
+    
+    return 0.0
+
+
+@metric
+def mean_absolute_deviation() -> Metric:
+    """Calculate Mean Absolute Deviation for CVSS score predictions."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"mean_absolute_deviation": 0.0}
+        
+        deviations = []
+        for score in scores:
+            if hasattr(score, 'metadata') and score.metadata:
+                predicted = score.metadata.get("predicted_score", 0.0)
+                actual = score.metadata.get("actual_score", 0.0)
+                deviation = abs(predicted - actual)
+                deviations.append(deviation)
+        
+        if not deviations:
+            return {"mean_absolute_deviation": 0.0}
+        
+        mad = sum(deviations) / len(deviations)
+        return {"mean_absolute_deviation": round(mad, 4)}
+    
+    return metric_fn
+
+
+@metric
+def accuracy_within_threshold() -> Metric:
+    """Calculate accuracy within 1.0 CVSS point threshold."""
+    def metric_fn(scores: List[SampleScore]) -> Value:
+        if not scores:
+            return {"accuracy_within_1_point": 0.0}
+        
+        correct = 0
+        for score in scores:
+            if hasattr(score, 'metadata') and score.metadata:
+                predicted = score.metadata.get("predicted_score", 0.0)
+                actual = score.metadata.get("actual_score", 0.0)
+                if abs(predicted - actual) <= 1.0:
+                    correct += 1
+        
+        accuracy = correct / len(scores)
+        return {"accuracy_within_1_point": round(accuracy, 4)}
+    
+    return metric_fn
+
+
+@scorer(metrics=[mean_absolute_deviation(), accuracy_within_threshold(), stderr()])
+def cti_bench_vsp_scorer() -> Callable:
+    """Scorer for CTI-Bench VSP (CVSS severity prediction) task."""
+    async def score(state: TaskState, target: Target) -> Score:
+        # Extract CVSS score from model response
+        predicted_score = extract_cvss_score(state.output.completion)
+        
+        try:
+            actual_score = float(target.text.strip())
+        except ValueError:
+            actual_score = 0.0
+        
+        # Calculate absolute deviation
+        absolute_deviation = abs(predicted_score - actual_score)
+        
+        # Score is inversely related to deviation (lower deviation = higher score)
+        # Use a score of 1.0 if deviation is 0, decreasing linearly
+        score_value = max(0.0, 1.0 - (absolute_deviation / 10.0))
+        
+        return Score(
+            value=score_value,
+            answer=str(predicted_score),
+            metadata={
+                "predicted_score": predicted_score,
+                "actual_score": actual_score,
+                "absolute_deviation": absolute_deviation,
+                "raw_output": state.output.completion,
+            }
+        )
+    return score


### PR DESCRIPTION
Adds CTI-Bench, a cybersecurity benchmark with 5 specialized tasks for evaluating LLMs on cyber threat intelligence:  MITRE ATT&CK technique extraction, multiple-choice CTI knowledge, CVE-to-CWE mapping, and CVSS scoring.

[https://github.com/xashru/cti-bench](url)