### PR TITLE
feat(vercel): add Vercel AI Gateway to supported model providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ OpenBench supports 30+ model providers through Inspect AI. Set the appropriate A
 | **Reka** | `REKA_API_KEY` | `reka/model-name` |
 | **SambaNova** | `SAMBANOVA_API_KEY` | `sambanova/model-name` |
 | **Together AI** | `TOGETHER_API_KEY` | `together/model-name` |
+| **Vercel AI Gateway** | `AI_GATEWAY_API_KEY` | `vercel/creator-name/model-name` |
 | **vLLM** | None (local) | `vllm/model-name` |
 
 ## Available Benchmarks

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -155,6 +155,14 @@ def moonshot() -> Type[ModelAPI]:
     return MoonshotAPI
 
 
+@modelapi(name="vercel")
+def vercel() -> Type[ModelAPI]:
+    """Register Vercel AI Gateway provider."""
+    from .model._providers.vercel import VercelAPI
+
+    return VercelAPI
+
+
 # Task Registration
 
 # Core benchmarks

--- a/src/openbench/model/_providers/vercel.py
+++ b/src/openbench/model/_providers/vercel.py
@@ -1,0 +1,64 @@
+"""Vercel AI Gateway provider implementation.
+
+The AI Gateway provides OpenAI-compatible API endpoints, letting you use multiple 
+AI providers through a familiar interface. The AI Gateway can route requests across 
+multiple AI providers for better reliability and performance.
+
+Environment variables:
+  - AI_GATEWAY_API_KEY: AI Gateway API key (required)
+  - AI_GATEWAY_BASE_URL: Override the default base URL (defaults to 
+    https://ai-gateway.vercel.sh/v1)
+
+Model naming follows the creator/model format, e.g.:
+  - anthropic/claude-sonnet-4
+  - openai/gpt-4.1-mini
+  - meta/llama-3.3-70b-instruct
+
+Website: https://vercel.com/ai-gateway
+Reference: https://vercel.com/docs/ai-gateway/openai-compatible-api
+"""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class VercelAPI(OpenAICompatibleAPI):
+    """Vercel AI Gateway provider - OpenAI-compatible API with multi-provider routing."""
+
+    DEFAULT_BASE_URL = "https://ai-gateway.vercel.sh/v1"
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Remove provider prefix if present
+        model_name_clean = model_name.replace("vercel/", "", 1)
+       
+        base_url = base_url or os.environ.get("AI_GATEWAY_BASE_URL") or self.DEFAULT_BASE_URL
+        api_key = api_key or os.environ.get("AI_GATEWAY_API_KEY") or os.environ.get("VERCEL_OIDC_TOKEN")
+
+        if not api_key:
+            raise ValueError(
+                "Vercel AI Gateway API key not found. Set the AI_GATEWAY_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="vercel",
+            service_base_url=self.DEFAULT_BASE_URL,
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
Hi! Love the work y'all have done with OpenBench and excited to see more benchmarks supported. 😊

This PR adds the [Vercel AI Gateway](https://vercel.com/ai-gateway) as a model provider, adding support for [100+ models](https://vercel.com/ai-gateway/models).

```
# Anthropic Claude 3 Haiku
bench eval mmlu --model vercel/anthropic/claude-3-haiku --limit 10

# OpenAI GPT-4o-mini
bench eval mmlu --model vercel/openai/gpt-4o-mini --limit 10
```