### PR TITLE
feat: add automated PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,7 +37,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ steps.release.outputs.release_created }}
+    if: ${{ needs.release.outputs.release_created }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add automated PyPI publishing job to release-please workflow
- Uses UV for building and publishing packages
- Only publishes when release-please creates a new release

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] Add PYPI_API_TOKEN secret to repository settings
- [ ] Test with a test release (or verify syntax validation passes)