### PR TITLE
fix: make claude-code-review job optional to prevent PR blocking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the claude-review job to prevent it from blocking other CI checks
- This allows PRs to be merged even if the Claude code review action fails due to OIDC token issues

## Problem
The claude-review job was failing with OIDC token errors, causing the "All Checks Pass" job to fail and blocking PR merges.

## Solution
Making the job optional allows it to provide value when it works while not blocking development workflow when it fails.

## Test plan
- [ ] Verify the workflow doesn't block PR merges when claude-review fails
- [ ] Confirm other CI jobs still run and are required for merge