### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: File a bug report to help us improve OpenBench
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenBench Version
+      description: What version of OpenBench are you running?
+      placeholder: "0.3.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run command '...'
+        2. With arguments '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command that failed
+      description: The exact command you ran that caused the issue
+      placeholder: "bench eval mmlu --model groq/llama-3.1-70b --limit 10"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error logs
+      description: Please copy and paste any relevant log output or error messages
+      render: shell
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: "3.11.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (environment, model provider, etc.)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature Request
+description: Suggest an idea for OpenBench
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature for OpenBench!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: "I'm always frustrated when..."
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: What are you requesting?
+      options:
+        - New benchmark/evaluation
+        - New model provider
+        - CLI enhancement
+        - Performance improvement
+        - Documentation
+        - API/SDK feature
+        - Integration (CI/CD, tools)
+        - Export/import functionality
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Describe your specific use case and how this feature would help you or others.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or examples about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary
+
+<!-- Briefly describe what this PR does -->
+
+## What are you adding?
+
+<!-- Mark with 'x' -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New benchmark/evaluation
+- [ ] New model provider
+- [ ] CLI enhancement
+- [ ] Performance improvement
+- [ ] Documentation update
+- [ ] API/SDK feature
+- [ ] Integration (CI/CD, tools)
+- [ ] Export/import functionality
+- [ ] Code refactoring
+- [ ] Breaking change
+- [ ] Other
+
+## Changes Made
+
+<!-- List the main changes in bullet points -->
+- 
+- 
+- 
+
+## Testing
+
+<!-- Describe how you tested your changes -->
+- [ ] I have run the existing test suite (`pytest`)
+- [ ] I have added tests for my changes
+- [ ] I have tested with multiple model providers (if applicable)
+- [ ] I have run pre-commit hooks (`pre-commit run --all-files`)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation (if applicable)
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Related Issues
+
+<!-- Link any related issues -->
+Closes #
+
+## Additional Context
+
+<!-- Add any other context about the pull request here -->


### PR DESCRIPTION
## Summary
- Add structured issue templates for bug reports and feature requests
- Add pull request template with OpenBench-specific categories
- Include fields for benchmarks, model providers, CLI enhancements, and other common contribution types

## What are you adding?
- [x] Documentation update
- [x] Integration (CI/CD, tools)

## Changes Made
- Created `.github/ISSUE_TEMPLATE/bug_report.yml` with structured bug reporting fields
- Created `.github/ISSUE_TEMPLATE/feature_request.yml` with OpenBench-specific feature categories
- Created `.github/pull_request_template.md` with comprehensive PR checklist and categories

## Test plan
- [x] Verify templates follow GitHub's YAML schema
- [x] Confirm all relevant OpenBench categories are included
- [x] Check that required fields are properly marked