### PR TITLE
docs: emphasize pre-commit hooks installation requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,14 @@ cd openbench
 uv venv && uv sync --dev
 source .venv/bin/activate
 
+# CRITICAL: Install pre-commit hooks (CI will fail without this!)
+pre-commit install
+
 # Run tests to verify setup
 pytest
 ```
+
+⚠️ **IMPORTANT**: You MUST install pre-commit hooks after `uv sync --dev`. CI will fail if you skip this step!
 
 ## 🎯 Core Principles
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,14 @@ cd openbench
 uv venv && uv sync --dev
 source .venv/bin/activate
 
+# CRITICAL: Install pre-commit hooks (CI will fail without this!)
+pre-commit install
+
 # Run tests
 pytest
 ```
+
+⚠️ **IMPORTANT**: You MUST run `pre-commit install` after setup or CI will fail on your PRs!
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Add clear pre-commit installation requirements to prevent CI failures
- Emphasize this critical step in both CONTRIBUTING.md and README.md development sections

## What are you adding?
- [x] Documentation update

## Changes Made
- Added `pre-commit install` step to CONTRIBUTING.md setup section
- Added `pre-commit install` step to README.md development section
- Included prominent warnings that CI will fail without pre-commit hooks
- Made the requirement very clear with warning emoji and bold text

## Test plan
- [x] Verify setup instructions are complete and accurate
- [x] Confirm warnings are prominent enough to prevent CI failures