### PR TITLE
chore: unpin dependencies except inspect-ai

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Essential Setup
 - Always source the virtual environment before running Python commands: `source .venv/bin/activate`
 - This project uses UV as the package manager, not pip
-- **Dependencies must be pinned**: When adding dependencies with UV, always pin to specific versions (e.g., `uv add package==1.2.3` not `uv add package`)
-  - Pin to the latest stable version available to keep dependencies healthy and secure
+- **Dependency management**: When adding dependencies with UV, use >= constraints (e.g., `uv add "package>=1.2.3"`)
+  - Exception: `inspect-ai` must remain pinned to a specific version for stability
+  - Use the latest stable version as the minimum to keep dependencies healthy and secure
   - Check latest versions with `uv pip list --outdated` or on PyPI
 
 ## Key Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ src/openbench/
 5. Update provider table in README.md
 
 ### Key Development Tools
-- **UV**: Package manager (not pip) - use `uv add package==version` for dependencies
+- **UV**: Package manager (not pip) - use `uv add "package>=version"` for dependencies (except inspect-ai which should remain pinned)
 - **Ruff**: Linting and formatting - replaces Black, isort, flake8
 - **MyPy**: Type checking - required for all new code
 - **Pre-commit**: Automated code quality checks - must pass before commits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,15 @@ authors = [
     { name="Groq" }
 ]
 dependencies = [
-    "datasets==3.6.0",
-    "groq==0.30.0",
+    "datasets",
+    "groq",
     "inspect-ai==0.3.115",
-    "openai==1.97.1",
-    "pydantic-settings==2.9.1",
+    "openai",
+    "pydantic-settings",
     "scicode",
-    "scipy==1.15.3",
-    "tiktoken==0.11.0",
-    "typer==0.15.3",
+    "scipy",
+    "tiktoken",
+    "typer",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,15 @@ authors = [
     { name="Groq" }
 ]
 dependencies = [
-    "datasets",
-    "groq",
+    "datasets>=3.6.0",
+    "groq>=0.30.0",
     "inspect-ai==0.3.115",
-    "openai",
-    "pydantic-settings",
+    "openai>=1.97.1",
+    "pydantic-settings>=2.9.1",
     "scicode",
-    "scipy",
-    "tiktoken",
-    "typer",
+    "scipy>=1.15.3",
+    "tiktoken>=0.11.0",
+    "typer>=0.15.3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2090,15 +2090,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datasets", specifier = "==3.6.0" },
-    { name = "groq", specifier = "==0.30.0" },
+    { name = "datasets", specifier = ">=3.6.0" },
+    { name = "groq", specifier = ">=0.30.0" },
     { name = "inspect-ai", specifier = "==0.3.115" },
-    { name = "openai", specifier = "==1.97.1" },
-    { name = "pydantic-settings", specifier = "==2.9.1" },
+    { name = "openai", specifier = ">=1.97.1" },
+    { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "scicode", git = "https://github.com/TheFloatingString/SciCode-fork.git?rev=4f20d721ba3e2227196262083b9b7a70484d54f7" },
-    { name = "scipy", specifier = "==1.15.3" },
-    { name = "tiktoken", specifier = "==0.11.0" },
-    { name = "typer", specifier = "==0.15.3" },
+    { name = "scipy", specifier = ">=1.15.3" },
+    { name = "tiktoken", specifier = ">=0.11.0" },
+    { name = "typer", specifier = ">=0.15.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Unpinned all dependencies except `inspect-ai` to allow uv to resolve the latest compatible versions
- `inspect-ai` remains pinned at version 0.3.115 for stability

## Why this change?
This allows the project to benefit from bug fixes and improvements in dependencies while maintaining flexibility for version resolution through uv's dependency resolver.

## Test plan
- [ ] Run `uv sync --dev` to verify dependencies resolve correctly
- [ ] Run test suite with `pytest` to ensure no breaking changes
- [ ] Verify CLI commands work as expected