### PR TITLE
fix: match JSONSchemaBench paper methodology (non-strict + schema ada…

### DIFF
--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -453,6 +453,7 @@ BENCHMARKS = {
         tags=["json", "jsonschema", "generation", "constrained-decoding"],
         module_path="openbench.evals.jsonschemabench",
         function_name="jsonschemabench",
+        is_alpha=True,
     ),
 }
 

--- a/src/openbench/evals/jsonschemabench.py
+++ b/src/openbench/evals/jsonschemabench.py
@@ -8,35 +8,110 @@ Dataset: https://huggingface.co/datasets/epfl-dlab/JSONSchemaBench
 """
 
 import json
+from jsonschema import Draft202012Validator
 from inspect_ai import Task, task
 from inspect_ai.solver import TaskState, Generate, solver
-from inspect_ai.model import GenerateConfig, ResponseSchema
+from inspect_ai.model import GenerateConfig, ResponseSchema, ModelOutput
 
 from openbench.datasets.jsonschemabench import get_dataset
 from openbench.scorers.json_schema import json_schema_scorer
 
 
+def add_root_type_if_missing(schema: dict) -> None:
+    """Add type: object if missing from schema root."""
+    if "type" not in schema:
+        schema["type"] = "object"
+
+
+def recursively_set_additional_properties_false(schema: dict) -> None:
+    """Recursively add additionalProperties: false to objects with properties."""
+    if not isinstance(schema, dict):
+        return
+    # Set additionalProperties to false if it's missing or true, and object has properties
+    if schema.get("properties") and (
+        "additionalProperties" not in schema or schema.get("additionalProperties", True)
+    ):
+        schema["additionalProperties"] = False
+    # Recurse into properties
+    if "properties" in schema:
+        for prop in schema["properties"]:
+            recursively_set_additional_properties_false(schema["properties"][prop])
+    # Recurse into array items
+    if "items" in schema:
+        recursively_set_additional_properties_false(schema["items"])
+
+
+def set_all_properties_required(schema: dict) -> dict:
+    """Recursively make all properties required in objects."""
+    if not isinstance(schema, dict):
+        return schema
+    if "properties" in schema:
+        schema["required"] = list(schema["properties"].keys())
+    for value in schema.values():
+        if isinstance(value, dict):
+            set_all_properties_required(value)
+        elif isinstance(value, list):
+            for item in value:
+                set_all_properties_required(item)
+    return schema
+
+
+def adapt_schema_for_openai(schema_dict: dict) -> dict:
+    """Adapt schema using JSONSchemaBench-style modifications for OpenAI compatibility."""
+    import copy
+    adapted_schema = copy.deepcopy(schema_dict)
+    add_root_type_if_missing(adapted_schema)
+    recursively_set_additional_properties_false(adapted_schema)
+    adapted_schema = set_all_properties_required(adapted_schema)
+    return adapted_schema
+
+
 @solver
-def structured_output_solver():
+def structured_output_solver(use_structured_output: bool = True, strict: bool = False, adapt_schema: bool = False):
     """Apply per-sample structured output for supported providers (OpenAI, Google, Mistral)."""
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         if not state.metadata or "schema" not in state.metadata:
             return await generate(state)
 
+        # Skip structured output if disabled
+        if not use_structured_output:
+            return await generate(state)
+
         try:
             schema_str = state.metadata["schema"]
             schema_dict = json.loads(schema_str)
+            
+            # Assert that it's a valid JSON Schema
+            Draft202012Validator.check_schema(schema_dict)
+            
+            # Apply schema adaptation if enabled and using structured output
+            if adapt_schema and use_structured_output:
+                schema_dict = adapt_schema_for_openai(schema_dict)
 
             return await generate(
                 state,
                 response_schema=ResponseSchema(
-                    name="json_schema_output", json_schema=schema_dict, strict=True
+                    name="json_schema_output", json_schema=schema_dict, strict=strict
                 ),
             )
 
-        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
-            return await generate(state)
+        except Exception as e:
+            # Schema validation failed - mark as API error instead of falling back
+            error_msg = f"schema_validation_error (strict={strict}): {str(e)}"
+            
+            # CSV format: dataset, split, strict, id, error, schema
+            dataset_info = getattr(state, 'sample_id', 'unknown')
+            subset = state.metadata.get('subset', 'unknown') if state.metadata else 'unknown'
+            schema_preview = schema_str.replace('"', '""').replace('\n', ' ')[:200] + "..." if len(schema_str) > 200 else schema_str.replace('"', '""').replace('\n', ' ')
+            csv_error = str(e).replace('"', '""').replace('\n', ' ')  # Escape CSV
+            csv_log = f"jsonschemabench,all,{strict},{dataset_info},{csv_error},\"{schema_preview}\""
+            print(csv_log)
+            
+            state.output = ModelOutput.from_content(
+                model="", content="", error=error_msg
+            )
+            return state
 
     return solve
 
@@ -47,6 +122,9 @@ def jsonschemabench(
     split: str = "all",
     num_shots: int = 0,
     strip_markdown: bool = True,
+    use_structured_output: bool = True,
+    strict: bool = False,
+    adapt_schema: bool = False,
 ) -> Task:
     """JSONSchemaBench: A Rigorous Benchmark of Structured Outputs
     for Language Models.
@@ -56,8 +134,7 @@ def jsonschemabench(
     schemas from GitHub, Kubernetes, APIs, and other sources.
 
     Uses structured output when supported by the provider for API-level
-    schema validation, otherwise falls back to text generation with
-    post-hoc validation.
+    schema validation, otherwise falls back to text generation withpost-hoc validation.
 
     See https://doi.org/10.48550/arXiv.2501.10868.
 
@@ -67,13 +144,16 @@ def jsonschemabench(
         split: Dataset split to use ("all", "test", "val", "train")
         num_shots: Number of few-shot examples to include (0 for zero-shot, paper used 2)
         strip_markdown: Whether to remove ```json``` markdown blocks from output (default True)
+        use_structured_output: Whether to use structured output when supported (default True)
+        strict: Whether to use strict mode for structured output (default True)
+        adapt_schema: Whether to adapt schemas for better provider compatibility (default False)
 
     Returns:
         Task configured for JSONSchemaBench evaluation
     """
     return Task(
         dataset=get_dataset(subset=subset, split=split, num_shots=num_shots),
-        solver=[structured_output_solver()],
+        solver=[structured_output_solver(use_structured_output=use_structured_output, strict=strict, adapt_schema=adapt_schema)],
         scorer=json_schema_scorer(strip_markdown=strip_markdown),
         name="jsonschemabench",
         config=GenerateConfig(


### PR DESCRIPTION
…ptation)

## Summary

<!-- Briefly describe what this PR does -->

Previously, calls to OpenAI were failing due to strict mode and not catching all exceptions. This PR now counts all exceptions as failed API calls.

However, this was yielding alarmingly low results for GPT-4o, far out of line with the paper. It turns out that the original implementation of JSONSchemaBench did not use strict mode, and alters the schema when making calls to the OpenAI API endpoints.

In my opinion, these are strange decisions, so I have added options to toggle these on/off, and set the defaults to what the paper had.

Additionally, the code to adapt the schemas for OpenAI in some cases remove most of the schema. This hardly seems fair or useful to me, so I have marked this eval as `alpha`, at least until these issues are fixed (we should perhaps try to contact the authors).


## What are you adding?

<!-- Mark with 'x' -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [x] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

<!-- List the main changes in bullet points -->
- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->
- [ ] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [ ] I have tested with multiple model providers (if applicable)
- [ ] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues -->
Closes #

## Additional Context

<!-- Add any other context about the pull request here -->