### PR TITLE
feat: graphwalks token filter

### DIFF
--- a/src/openbench/datasets/graphwalks.py
+++ b/src/openbench/datasets/graphwalks.py
@@ -43,7 +43,7 @@ def record_to_sample(
 
         return Sample(
             input=prompt,
-            target=str(record.get("answer_nodes")),
+            target=record.get("answer_nodes", []),
             metadata=metadata,
         )
 

--- a/src/openbench/datasets/graphwalks.py
+++ b/src/openbench/datasets/graphwalks.py
@@ -5,6 +5,7 @@ from openbench.utils.text import get_token_count
 
 _ALLOWED = {"bfs", "parents"}
 
+
 def record_to_sample(
     allowed: Optional[set[str]] = None,
     max_context_size: Optional[int] = None,
@@ -24,20 +25,20 @@ def record_to_sample(
         # problem type filter
         if allowed is not None and problem_type not in allowed:
             return []
-        
+
         # calculate tokens
         prompt = str(record.get("prompt"))
         tok_cnt = int(get_token_count(prompt))
-        
+
         # token filter if max_context_size is provided
         if max_context_size is not None and tok_cnt > max_context_size:
             return []
-        
+
         metadata = {
             "problem_type": problem_type,
             "n_chars": record.get("prompt_chars"),
             "raw_input_tok_cnt": tok_cnt,
-            "target": record.get("answer_nodes")
+            "target": record.get("answer_nodes"),
         }
 
         return Sample(
@@ -65,5 +66,7 @@ def get_dataset(
     return hf_dataset(
         path="openai/graphwalks",
         split=split,
-        sample_fields=record_to_sample(allowed=allowed, max_context_size=max_context_size),
+        sample_fields=record_to_sample(
+            allowed=allowed, max_context_size=max_context_size
+        ),
     )

--- a/src/openbench/datasets/graphwalks.py
+++ b/src/openbench/datasets/graphwalks.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import Any, Optional, Callable
 from inspect_ai.dataset import Dataset, Sample, hf_dataset, FieldSpec
-from openbench.utils.text import get_token_count  # plain text token counter
+from openbench.utils.text import get_token_count
 
 _ALLOWED = {"bfs", "parents"}
 
@@ -12,38 +12,42 @@ def record_to_sample(
     max_context_size: Optional[int] = None,
 ) -> FieldSpec | Callable[[dict[str, Any]], Sample | list[Sample]]:
     """
-    Create a mapper from GraphWalks records to Inspect Samples.
-
-    - If `allowed` is provided, drop rows whose problem_type isn't in it by returning [].
-    - If `max_context_size` is provided, drop rows whose prompt token count exceeds it.
+    Map one HF row to an Inspect Sample.
+    - If `allowed` is provided, drop rows whose problem_type isn't in it (return []).
+    - If `max_context_size` is provided, compute token count and drop rows that exceed it.
     """
 
     def _record_to_sample(record: dict[str, Any]) -> Sample | list[Sample]:
         problem_type = (record.get("problem_type") or "").strip().lower()
 
-        # Keep/skip by problem type (early drop)
+        # Type filter (fast) — do this first
         if allowed is not None and problem_type not in allowed:
             return []
 
         prompt: str = record["prompt"]
-        # Count tokens in the same format you will send to the model (plain text here)
-        tok_cnt = get_token_count(prompt)
 
-        # Early drop by token budget (MRCR-style gating)
-        if max_context_size is not None and tok_cnt > max_context_size:
-            return []
+        tok_cnt: Optional[int] = None
+        if max_context_size is not None:
+            # Only compute tokens when we actually need gating
+            try:
+                tok_cnt = int(get_token_count(prompt))
+            except Exception:
+                # Never block the pipeline on tokenization; default to a large value so it won't be dropped by mistake
+                tok_cnt = 0
+
+            if tok_cnt > max_context_size:
+                return []
 
         gold = record.get("answer", record.get("answer_nodes", []))
 
-        return Sample(
-            input=prompt,
-            target=gold,
-            metadata={
-                "problem_type": problem_type,
-                "prompt_chars": record.get("prompt_chars"),
-                "raw_input_tok_cnt": tok_cnt,  # consumed by scorer/metrics for binning
-            },
-        )
+        md = {
+            "problem_type": problem_type,
+            "prompt_chars": record.get("prompt_chars"),
+        }
+        if tok_cnt is not None:
+            md["raw_input_tok_cnt"] = tok_cnt
+
+        return Sample(input=prompt, target=gold, metadata=md)
 
     return _record_to_sample
 
@@ -55,7 +59,6 @@ def get_dataset(
 ) -> Dataset:
     """
     task_type: 'bfs' | 'parents' | 'both' (default: keep all)
-    max_context_size: if set, drop samples whose prompt token count exceeds this value
     """
     task = (task_type or "both").strip().lower()
     if task in ("both", "all", "*"):

--- a/src/openbench/datasets/graphwalks.py
+++ b/src/openbench/datasets/graphwalks.py
@@ -1,4 +1,3 @@
-# src/openbench/datasets/graphwalks.py
 from __future__ import annotations
 from typing import Any, Optional, Callable
 from inspect_ai.dataset import Dataset, Sample, hf_dataset, FieldSpec
@@ -6,48 +5,54 @@ from openbench.utils.text import get_token_count
 
 _ALLOWED = {"bfs", "parents"}
 
+def _estimate_tokens_from_chars(chars: int) -> int:
+    # Simple, conservative chars→tokens conversion
+    return max(1, (chars + 3) // 4)
 
 def record_to_sample(
     allowed: Optional[set[str]] = None,
     max_context_size: Optional[int] = None,
 ) -> FieldSpec | Callable[[dict[str, Any]], Sample | list[Sample]]:
-    """
-    Map one HF row to an Inspect Sample.
-    - If `allowed` is provided, drop rows whose problem_type isn't in it (return []).
-    - If `max_context_size` is provided, compute token count and drop rows that exceed it.
-    """
 
     def _record_to_sample(record: dict[str, Any]) -> Sample | list[Sample]:
         problem_type = (record.get("problem_type") or "").strip().lower()
 
-        # Type filter (fast) — do this first
+        # 1) Cheap type filter
         if allowed is not None and problem_type not in allowed:
             return []
 
         prompt: str = record["prompt"]
 
-        tok_cnt: Optional[int] = None
-        if max_context_size is not None:
-            # Only compute tokens when we actually need gating
-            try:
-                tok_cnt = int(get_token_count(prompt))
-            except Exception:
-                # Never block the pipeline on tokenization; default to a large value so it won't be dropped by mistake
-                tok_cnt = 0
+        # 2) Always compute (or estimate) token count for binning/metrics
+        try:
+            tok_cnt = int(get_token_count(prompt))
+        except Exception:
+            # Fall back to a reasonable estimate based on characters
+            tok_cnt = _estimate_tokens_from_chars(int(record.get("prompt_chars") or len(prompt)))
 
-            if tok_cnt > max_context_size:
-                return []
+        # 3) Optional gating by max_context_size (use exact count only;
+        #    if we only had an estimate due to error, do NOT drop)
+        if max_context_size is not None:
+            try:
+                exact_tok_cnt = int(get_token_count(prompt))  # re-try once for gating accuracy
+                if exact_tok_cnt > max_context_size:
+                    return []
+                tok_cnt = exact_tok_cnt  # keep exact value in metadata
+            except Exception:
+                # If tokenizer still fails, do not drop on an estimate
+                pass
 
         gold = record.get("answer", record.get("answer_nodes", []))
 
-        md = {
-            "problem_type": problem_type,
-            "prompt_chars": record.get("prompt_chars"),
-        }
-        if tok_cnt is not None:
-            md["raw_input_tok_cnt"] = tok_cnt
-
-        return Sample(input=prompt, target=gold, metadata=md)
+        return Sample(
+            input=prompt,
+            target=gold,
+            metadata={
+                "problem_type": problem_type,
+                "prompt_chars": record.get("prompt_chars"),
+                "raw_input_tok_cnt": tok_cnt,   # <- always set
+            },
+        )
 
     return _record_to_sample
 
@@ -57,9 +62,6 @@ def get_dataset(
     task_type: str = "both",
     max_context_size: Optional[int] = None,
 ) -> Dataset:
-    """
-    task_type: 'bfs' | 'parents' | 'both' (default: keep all)
-    """
     task = (task_type or "both").strip().lower()
     if task in ("both", "all", "*"):
         allowed = None

--- a/src/openbench/datasets/graphwalks.py
+++ b/src/openbench/datasets/graphwalks.py
@@ -1,39 +1,61 @@
 # src/openbench/datasets/graphwalks.py
 from __future__ import annotations
-from typing import Any, Optional
-from inspect_ai.dataset import Dataset, Sample, hf_dataset
+from typing import Any, Optional, Callable
+from inspect_ai.dataset import Dataset, Sample, hf_dataset, FieldSpec
+from openbench.utils.text import get_token_count  # plain text token counter
 
 _ALLOWED = {"bfs", "parents"}
 
 
 def record_to_sample(
-    record: dict[str, Any], *, allowed: Optional[set[str]] = None
-) -> Sample | list[Sample]:
+    allowed: Optional[set[str]] = None,
+    max_context_size: Optional[int] = None,
+) -> FieldSpec | Callable[[dict[str, Any]], Sample | list[Sample]]:
     """
-    Map one HF row to an Inspect Sample.
-    If `allowed` is provided, drop rows whose problem_type isn't in it by returning empty list.
+    Create a mapper from GraphWalks records to Inspect Samples.
+
+    - If `allowed` is provided, drop rows whose problem_type isn't in it by returning [].
+    - If `max_context_size` is provided, drop rows whose prompt token count exceeds it.
     """
-    problem_type = (record.get("problem_type") or "").strip().lower()
 
-    # Filter here by returning empty list (row is skipped)
-    if allowed is not None and problem_type not in allowed:
-        return []
+    def _record_to_sample(record: dict[str, Any]) -> Sample | list[Sample]:
+        problem_type = (record.get("problem_type") or "").strip().lower()
 
-    gold = record.get("answer", record.get("answer_nodes", []))
+        # Keep/skip by problem type (early drop)
+        if allowed is not None and problem_type not in allowed:
+            return []
 
-    return Sample(
-        input=record["prompt"],
-        target=gold,
-        metadata={
-            "problem_type": problem_type,
-            "prompt_chars": record.get("prompt_chars"),
-        },
-    )
+        prompt: str = record["prompt"]
+        # Count tokens in the same format you will send to the model (plain text here)
+        tok_cnt = get_token_count(prompt)
+
+        # Early drop by token budget (MRCR-style gating)
+        if max_context_size is not None and tok_cnt > max_context_size:
+            return []
+
+        gold = record.get("answer", record.get("answer_nodes", []))
+
+        return Sample(
+            input=prompt,
+            target=gold,
+            metadata={
+                "problem_type": problem_type,
+                "prompt_chars": record.get("prompt_chars"),
+                "raw_input_tok_cnt": tok_cnt,  # consumed by scorer/metrics for binning
+            },
+        )
+
+    return _record_to_sample
 
 
-def get_dataset(split: str = "train", task_type: str = "both") -> Dataset:
+def get_dataset(
+    split: str = "train",
+    task_type: str = "both",
+    max_context_size: Optional[int] = None,
+) -> Dataset:
     """
     task_type: 'bfs' | 'parents' | 'both' (default: keep all)
+    max_context_size: if set, drop samples whose prompt token count exceeds this value
     """
     task = (task_type or "both").strip().lower()
     if task in ("both", "all", "*"):
@@ -43,11 +65,8 @@ def get_dataset(split: str = "train", task_type: str = "both") -> Dataset:
     else:
         raise ValueError("task_type must be one of 'bfs', 'parents', 'both'")
 
-    def _map_sample(rec: dict[str, Any]) -> Sample | list[Sample]:
-        return record_to_sample(rec, allowed=allowed)
-
     return hf_dataset(
         path="openai/graphwalks",
         split=split,
-        sample_fields=_map_sample,
+        sample_fields=record_to_sample(allowed=allowed, max_context_size=max_context_size),
     )

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -8,9 +8,13 @@ from openbench.datasets.graphwalks import get_dataset
 from openbench.scorers.graphwalks import graphwalks_scorer
 
 @task
-def graphwalks(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+def graphwalks(
+    split: str = "train", 
+    max_context_size: Optional[int] = None,
+    task_type: str = "both",
+) -> Task:
     return Task(
-        dataset=get_dataset(split=split, task_type="both", max_context_size=max_context_size),
+        dataset=get_dataset(split=split, task_type=task_type, max_context_size=max_context_size),
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks",

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -7,34 +7,47 @@ from inspect_ai.solver import generate
 from openbench.datasets.graphwalks import get_dataset
 from openbench.scorers.graphwalks import graphwalks_scorer
 
+
 @task
 def graphwalks(
-    split: str = "train", 
+    split: str = "train",
     max_context_size: Optional[int] = None,
     task_type: str = "both",
 ) -> Task:
     return Task(
-        dataset=get_dataset(split=split, task_type=task_type, max_context_size=max_context_size),
+        dataset=get_dataset(
+            split=split, task_type=task_type, max_context_size=max_context_size
+        ),
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=8192),
     )
 
+
 @task
-def graphwalks_bfs(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+def graphwalks_bfs(
+    split: str = "train", max_context_size: Optional[int] = None
+) -> Task:
     return Task(
-        dataset=get_dataset(split=split, task_type="bfs", max_context_size=max_context_size),
+        dataset=get_dataset(
+            split=split, task_type="bfs", max_context_size=max_context_size
+        ),
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_bfs",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=8192),
     )
 
+
 @task
-def graphwalks_parents(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+def graphwalks_parents(
+    split: str = "train", max_context_size: Optional[int] = None
+) -> Task:
     return Task(
-        dataset=get_dataset(split=split, task_type="parents", max_context_size=max_context_size),
+        dataset=get_dataset(
+            split=split, task_type="parents", max_context_size=max_context_size
+        ),
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_parents",

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -1,6 +1,7 @@
 # src/openbench/evals/graphwalks.py
 from __future__ import annotations
 
+from typing import Optional
 from inspect_ai import task, Task
 from inspect_ai.model import GenerateConfig
 from inspect_ai.solver import generate
@@ -10,10 +11,11 @@ from openbench.scorers.graphwalks import graphwalks_scorer
 
 
 @task
-def graphwalks(split: str = "train") -> Task:
+def graphwalks(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+    """Graphwalks evaluation task with optional token filtering."""
     return Task(
-        dataset=get_dataset(split=split, task_type="both"),
-        solver=[generate()],
+        dataset=get_dataset(split=split, task_type="both", max_context_size=max_context_size),
+        solver=generate(),
         scorer=graphwalks_scorer(),
         name="graphwalks",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
@@ -21,10 +23,11 @@ def graphwalks(split: str = "train") -> Task:
 
 
 @task
-def graphwalks_bfs(split: str = "train") -> Task:
+def graphwalks_bfs(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+    """Graphwalks BFS-only evaluation task with optional token filtering."""
     return Task(
-        dataset=get_dataset(split=split, task_type="bfs"),
-        solver=[generate()],
+        dataset=get_dataset(split=split, task_type="bfs", max_context_size=max_context_size),
+        solver=generate(),
         scorer=graphwalks_scorer(),
         name="graphwalks_bfs",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
@@ -32,10 +35,11 @@ def graphwalks_bfs(split: str = "train") -> Task:
 
 
 @task
-def graphwalks_parents(split: str = "train") -> Task:
+def graphwalks_parents(split: str = "train", max_context_size: Optional[int] = None) -> Task:
+    """Graphwalks Parents-only evaluation task with optional token filtering."""
     return Task(
-        dataset=get_dataset(split=split, task_type="parents"),
-        solver=[generate()],
+        dataset=get_dataset(split=split, task_type="parents", max_context_size=max_context_size),
+        solver=generate(),
         scorer=graphwalks_scorer(),
         name="graphwalks_parents",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -14,7 +14,7 @@ def graphwalks(split: str = "train", max_context_size: Optional[int] = None) -> 
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks",
-        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
+        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=8192),
     )
 
 @task
@@ -24,7 +24,7 @@ def graphwalks_bfs(split: str = "train", max_context_size: Optional[int] = None)
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_bfs",
-        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
+        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=8192),
     )
 
 @task
@@ -34,5 +34,5 @@ def graphwalks_parents(split: str = "train", max_context_size: Optional[int] = N
         solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_parents",
-        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
+        config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=8192),
     )

--- a/src/openbench/evals/graphwalks.py
+++ b/src/openbench/evals/graphwalks.py
@@ -1,45 +1,37 @@
 # src/openbench/evals/graphwalks.py
 from __future__ import annotations
-
 from typing import Optional
 from inspect_ai import task, Task
 from inspect_ai.model import GenerateConfig
 from inspect_ai.solver import generate
-
 from openbench.datasets.graphwalks import get_dataset
 from openbench.scorers.graphwalks import graphwalks_scorer
 
-
 @task
 def graphwalks(split: str = "train", max_context_size: Optional[int] = None) -> Task:
-    """Graphwalks evaluation task with optional token filtering."""
     return Task(
         dataset=get_dataset(split=split, task_type="both", max_context_size=max_context_size),
-        solver=generate(),
+        solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
     )
 
-
 @task
 def graphwalks_bfs(split: str = "train", max_context_size: Optional[int] = None) -> Task:
-    """Graphwalks BFS-only evaluation task with optional token filtering."""
     return Task(
         dataset=get_dataset(split=split, task_type="bfs", max_context_size=max_context_size),
-        solver=generate(),
+        solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_bfs",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),
     )
 
-
 @task
 def graphwalks_parents(split: str = "train", max_context_size: Optional[int] = None) -> Task:
-    """Graphwalks Parents-only evaluation task with optional token filtering."""
     return Task(
         dataset=get_dataset(split=split, task_type="parents", max_context_size=max_context_size),
-        solver=generate(),
+        solver=[generate()],
         scorer=graphwalks_scorer(),
         name="graphwalks_parents",
         config=GenerateConfig(temperature=0.0, top_p=1.0, max_tokens=256),

--- a/src/openbench/scorers/graphwalks.py
+++ b/src/openbench/scorers/graphwalks.py
@@ -2,16 +2,26 @@
 from __future__ import annotations
 
 import re
-from typing import Set
+from typing import Set, Iterable, Tuple
 
-from inspect_ai.scorer import scorer, Score, Target, mean, stderr
+from inspect_ai.scorer import (
+    scorer,
+    Score,
+    Target,
+    mean,
+    stderr,
+    Metric,
+    Value,
+    SampleScore,
+    metric,
+)
+from openbench.utils.text import get_token_count
 
-# Parse ONLY the very last line, which must look like:
-#   Final Answer: [a, b, c]
+# Match "Final Answer: [a, b, c]" at the end of output
 _FINAL_LINE_RE = re.compile(r"Final Answer:\s*\[(.*)\]\s*$", re.IGNORECASE)
 
 
-def _parse_nodes(text: str) -> tuple[list[str], bool]:
+def _parse_nodes(text: str) -> Tuple[list[str], bool]:
     """Return (nodes, parse_error_flag). Dedup while preserving order."""
     if not text:
         return [], True
@@ -20,7 +30,6 @@ def _parse_nodes(text: str) -> tuple[list[str], bool]:
     if not m:
         return [], True
     inner = m.group(1)
-    # split by commas only; trim; drop empties; dedup preserving order
     raw = [t.strip() for t in inner.split(",")]
     seen: Set[str] = set()
     out: list[str] = []
@@ -31,7 +40,7 @@ def _parse_nodes(text: str) -> tuple[list[str], bool]:
     return out, False
 
 
-def _prf1(pred: list[str], gold: list[str]) -> tuple[float, float, float]:
+def _prf1(pred: Iterable[str], gold: Iterable[str]) -> Tuple[float, float, float]:
     sp, sg = set(pred), set(gold)
     inter = len(sp & sg)
     p = inter / len(sp) if sp else 0.0
@@ -40,10 +49,63 @@ def _prf1(pred: list[str], gold: list[str]) -> tuple[float, float, float]:
     return p, r, f1
 
 
-@scorer(metrics=[mean(), stderr()])  # UI will show Mean (and stderr) of F1
+GRAPHWALKS_BINS = [
+    (0, 512),
+    (512, 1024),
+    (1024, 2048),
+    (2048, 4096),
+    (4096, 8192),
+    (8192, 16384),
+    (16384, 32768),
+    (32768, 65536),
+]
+
+
+@metric
+def graphwalks_metrics() -> Metric:
+    """Report mean precision / recall / f1 per token bin."""
+    def metric_calculator(scores: list[SampleScore]) -> Value:
+        f1_by_bin = {f"{L}-{R}": 0.0 for (L, R) in GRAPHWALKS_BINS}
+        p_by_bin = {f"{L}-{R}": 0.0 for (L, R) in GRAPHWALKS_BINS}
+        r_by_bin = {f"{L}-{R}": 0.0 for (L, R) in GRAPHWALKS_BINS}
+        counts = {f"{L}-{R}": 0 for (L, R) in GRAPHWALKS_BINS}
+
+        for s in scores:
+            md = s.score.metadata or {}
+            tok = int(md.get("raw_input_tok_cnt", 0))
+            p = float(md.get("precision", 0.0))
+            r = float(md.get("recall", 0.0))
+            f1 = float(md.get("f1", 0.0))
+
+            for i, (L, R) in enumerate(GRAPHWALKS_BINS):
+                if (i == 0 and L <= tok <= R) or (i > 0 and L < tok <= R):
+                    k = f"{L}-{R}"
+                    f1_by_bin[k] += f1
+                    p_by_bin[k] += p
+                    r_by_bin[k] += r
+                    counts[k] += 1
+                    break
+
+        # average per bin
+        for k in f1_by_bin.keys():
+            if counts[k] > 0:
+                f1_by_bin[k] /= counts[k]
+                p_by_bin[k] /= counts[k]
+                r_by_bin[k] /= counts[k]
+
+        return {
+            "f1_by_token_count": f1_by_bin,
+            "precision_by_token_count": p_by_bin,
+            "recall_by_token_count": r_by_bin,
+            "samples_per_bin": counts,
+        }
+
+    return metric_calculator
+
+
+@scorer(metrics=[mean(), stderr(), graphwalks_metrics()])
 def graphwalks_scorer():
     async def score(state, target: Target) -> Score:
-        # Inspect model output: prefer .completion, fall back to .text if needed
         out = ""
         if getattr(state, "output", None) is not None:
             out = (
@@ -53,11 +115,15 @@ def graphwalks_scorer():
             )
 
         pred, parse_err = _parse_nodes(out)
-        gold = list(target)  # Target is a sequence of gold node strings
-
+        gold = list(target)
         p, r, f1 = _prf1(pred, gold)
+
+        # use precomputed token count if available, else compute on the fly
+        md = getattr(state, "metadata", None) or {}
+        tok_cnt = int(md.get("raw_input_tok_cnt") or get_token_count(str(state.input)))
+
         return Score(
-            value=f1,  # Mean in the UI = mean F1
+            value=f1,
             answer=str(pred),
             metadata={
                 "precision": p,
@@ -66,6 +132,7 @@ def graphwalks_scorer():
                 "parsed_ok": (not parse_err),
                 "pred": pred,
                 "gold": gold,
+                "raw_input_tok_cnt": tok_cnt,
             },
         )
 

--- a/src/openbench/scorers/graphwalks.py
+++ b/src/openbench/scorers/graphwalks.py
@@ -9,7 +9,6 @@ from inspect_ai.scorer import (
     Score,
     Target,
     mean,
-    stderr,
     Metric,
     Value,
     SampleScore,

--- a/src/openbench/scorers/graphwalks.py
+++ b/src/openbench/scorers/graphwalks.py
@@ -21,7 +21,7 @@ from openbench.utils.text import get_token_count
 def _parse_nodes(response: str) -> tuple[list[str], bool]:
     # get last line of assistant response
     last_line = response.split("\n")[-1]
-    
+
     # check formatting with case-insensitive matching
     if "final answer:" not in last_line.lower():
         return [], True
@@ -33,7 +33,7 @@ def _parse_nodes(response: str) -> tuple[list[str], bool]:
         # return [] if empty list (not [""])
         result_list = [item.strip() for item in inner.split(",") if item.strip()]
         # in-order deduplication
-        result_list = list(dict.fromkeys(result_list))  
+        result_list = list(dict.fromkeys(result_list))
         return result_list, False
     else:
         return [], True

--- a/src/openbench/scorers/graphwalks.py
+++ b/src/openbench/scorers/graphwalks.py
@@ -20,16 +20,20 @@ from openbench.utils.text import get_token_count
 
 def _parse_nodes(response: str) -> tuple[list[str], bool]:
     # get last line of assistant response
-    line = response.split("\n")[-1]
-    # check formatting
-    if "Final Answer:" not in line:
+    last_line = response.split("\n")[-1]
+    
+    # check formatting with case-insensitive matching
+    if "final answer:" not in last_line.lower():
         return [], True
 
-    list_part = re.search(r"Final Answer: ?\[(.*)\]", line)
+    # more flexible regex with case-insensitive flag and end-of-line anchor
+    list_part = re.search(r"final answer:\s*\[(.*)\]\s*$", last_line, re.IGNORECASE)
     if list_part:
         inner = list_part.group(1)
         # return [] if empty list (not [""])
         result_list = [item.strip() for item in inner.split(",") if item.strip()]
+        # in-order deduplication
+        result_list = list(dict.fromkeys(result_list))  
         return result_list, False
     else:
         return [], True


### PR DESCRIPTION
## Summary

Adds optional token-count–based filtering to the GraphWalks dataset pipeline.
Samples that exceed user-specified max_context_size are now dropped during dataset preparation, constraining evals to contexts within a token budget.

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [x] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

- Extended record_to_sample in graphwalks.py to:
    - Compute input token counts via get_token_count.
    - Drop records whose token length exceeds max_context_size.
    - Attach raw_input_tok_cnt to sample metadata for downstream metrics 
- Updated get_dataset to accept max_context_size and pass it through to the mapper.

## Testing

<!-- Describe how you tested your changes -->
- [X]  Ran evaluation with and without -T max_context_size
- [X] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [ ] I have tested with multiple model providers (if applicable)
- [X] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Context

This feature mirrors the MRCR evaluation’s token gating strategy, but is adapted for GraphWalks.
It provides a consistent mechanism for controlling dataset size relative to model context limits, and sets up future work on token-binned scoring.
