### PR TITLE
feat: mbpp

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -173,6 +173,7 @@ from .evals.healthbench import healthbench, healthbench_hard, healthbench_consen
 from .evals.hle import hle, hle_text  # noqa: F401, E402
 from .evals.humaneval import humaneval  # noqa: F401, E402
 from .evals.math import math, math_500  # noqa: F401, E402
+from .evals.mbpp import mbpp  # noqa: F401, E402
 from .evals.mgsm import mgsm, mgsm_en, mgsm_latin, mgsm_non_latin  # noqa: F401, E402
 from .evals.mmlu import mmlu  # noqa: F401, E402
 from .evals.mrcr import openai_mrcr, openai_mrcr_2n, openai_mrcr_4n, openai_mrcr_8n  # noqa: F401, E402

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -34,6 +34,15 @@ class BenchmarkMetadata:
 
 # Benchmark metadata - minimal, no duplication
 BENCHMARKS = {
+    "mbpp": BenchmarkMetadata(
+    name="MBPP",
+    description="Mostly Basic Python Problems — code generation tasks with unit test verification",
+    category="core",
+    tags=["code", "generation", "sandbox", "reasoning"],
+    module_path="openbench.evals.mbpp",
+    function_name="mbpp",
+    is_alpha=False,
+    ),
     # Graphwalks benchmarks (alpha)
     "graphwalks": BenchmarkMetadata(
         name="GraphWalks",

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -35,13 +35,13 @@ class BenchmarkMetadata:
 # Benchmark metadata - minimal, no duplication
 BENCHMARKS = {
     "mbpp": BenchmarkMetadata(
-    name="MBPP",
-    description="Mostly Basic Python Problems — code generation tasks with unit test verification",
-    category="core",
-    tags=["code", "generation", "sandbox", "reasoning"],
-    module_path="openbench.evals.mbpp",
-    function_name="mbpp",
-    is_alpha=False,
+        name="MBPP",
+        description="Mostly Basic Python Problems — code generation tasks with unit test verification",
+        category="core",
+        tags=["code", "generation", "sandbox", "reasoning"],
+        module_path="openbench.evals.mbpp",
+        function_name="mbpp",
+        is_alpha=False,
     ),
     # Graphwalks benchmarks (alpha)
     "graphwalks": BenchmarkMetadata(

--- a/src/openbench/datasets/mbpp.py
+++ b/src/openbench/datasets/mbpp.py
@@ -1,123 +1,104 @@
+# src/openbench/datasets/mbpp.py
+"""
+MBPP dataset adapter (sanitized/test) for OpenBench (Inspect).
+
+- Loads: Muennighoff/mbpp (config="sanitized", split="test")
+- Builds chat-style Samples with the *paper-style* prompt:
+    "You are an expert Python programmer, and here is your task: {prompt}
+     Your code should pass these tests:
+
+     {tests}
+     [BEGIN]
+     {code}
+     [DONE]"
+
+No entry-point inference is performed; the tests reveal the function name.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from inspect_ai.dataset import Dataset, Sample, hf_dataset, FieldSpec
+from inspect_ai.dataset import Dataset, Sample, FieldSpec, hf_dataset
 from inspect_ai.model import ChatMessageUser
 
-MBPP_INSTRUCTION = """
-    You will be given a short Python programming task.
-    Write a single Python function that satisfies the prompt.
-    Your response should only contain the code for this function.
-    """.strip()
-
-# Normalize keys that commonly appear across MBPP variants.
-_TEST_LIST_KEYS = ("test_list", "challenge_test_list")
-_SETUP_KEYS = ("test_imports", "test_setup_code", "imports", "setup_code")
-_PROMPT_KEYS = ("prompt", "text", "task_description")
-_CODE_KEYS = ("code", "solution", "canonical_solution", "reference_code")
-
-
-def _get_first(record: Dict[str, Any], *candidates: str, default: Any = None) -> Any:
-    """Return the first present, non-empty value among candidate keys."""
-    for k in candidates:
-        if k in record and record[k] not in (None, ""):
-            return record[k]
+def _get_first(rec: Dict[str, Any], *keys: str, default: Any = None) -> Any:
+    for k in keys:
+        if k in rec and rec[k] not in (None, ""):
+            return rec[k]
     return default
 
+def _normalize_tests(tests: Any) -> List[str]:
+    if tests is None:
+        return []
+    if isinstance(tests, list):
+        return [str(t).rstrip() for t in tests if str(t).strip()]
+    if isinstance(tests, str):
+        return [ln.rstrip() for ln in tests.splitlines() if ln.strip()]
+    return []
 
-def record_to_sample(
-    instruction_prompt: str = MBPP_INSTRUCTION,
-    include_reference_in_target: bool = True,
-) -> FieldSpec | Callable[[Dict[str, Any]], Sample]:
+PROMPT_TEMPLATE = (
+    "You are an expert Python programmer, and here is your task: {prompt} "
+    "Your code should pass these tests:\n\n"
+    "{tests}\n"
+    "[BEGIN]\n"
+    "{code}\n"
+    "[DONE]"
+)
+
+def record_to_sample() -> FieldSpec | Callable[[Dict[str, Any]], Sample]:
     """
-    Mapper from MBPP records to Inspect Samples.
-
-    Parameters:
-        instruction_prompt : str
-            A prefix instruction prepended to the MBPP problem statement. This helps
-            constrain the model to emit a single function with no extra text.
-        include_reference_in_target : bool
-            If True, set `Sample.target` to the dataset's reference code (when available).
-            Scorers for code-exec usually don't *use* target, but it's handy for debugging.
+    Map a raw MBPP record to an Inspect Sample using the paper-style prompt.
     """
-
     def _map(record: Dict[str, Any]) -> Sample:
-        # Identify an ID if present (task_id is common in MBPP)
-        task_id = str(_get_first(record, "task_id", "id", default="")).strip() or None
+        # primary fields (sanitized schema)
+        task_id = str(record.get("task_id", "") or "").strip() or None
+        prompt_text = str(record["prompt"]).strip()
 
-        # Problem statement (prompt)
-        prompt_text = str(_get_first(record, *_PROMPT_KEYS, default="")).strip()
-        if not prompt_text:
-            # Defensive: some variants may store the prompt under 'question'
-            prompt_text = str(record.get("question", "")).strip()
+        # optional fields
+        tests_list = _normalize_tests(record.get("test_list", []))
+        reference = record.get("code") or None
 
-        # Tests and optional setup/imports
-        # test_list is commonly a list[str] of assert statements
-        tests = _get_first(record, *_TEST_LIST_KEYS, default=None)
-        # test setup/imports may be a string block with imports or helper defs
-        setup = _get_first(record, *_SETUP_KEYS, default=None)
+        # normalize setup
+        raw_setup = record.get("test_imports")
+        if isinstance(raw_setup, list):
+            setup = "\n".join(s for s in (str(x).rstrip() for x in raw_setup) if s) or None
+        else:
+            setup = (str(raw_setup).strip() or None) if raw_setup is not None else None
 
-        # Optional reference code (not executed by the scorer, but useful)
-        reference = _get_first(record, *_CODE_KEYS, default=None)
+        # build user message
+        tests_block = "\n".join(tests_list)
+        user_text = PROMPT_TEMPLATE.format(
+            prompt=prompt_text,
+            tests=tests_block,
+            code="{code}",  # literal placeholder per published paper format
+        )
 
-        # Build the chat-style input: a single user message with instruction + prompt
-        user_msg = ChatMessageUser(content=f"{instruction_prompt}\n\n{prompt_text}".strip())
-
-        # Metadata that the scorer will use to assemble the harness
-        metadata: Dict[str, Any] = {
+        metadata = {
             "task_id": task_id,
             "prompt": prompt_text,
-            "tests": tests,                 # expected: list[str] of asserts (or None)
-            "setup": setup,                 # expected: str with imports/setup (or None)
-            "reference_code": reference,    # optional debugging aid
+            "tests": tests_list,          # list[str] of assert lines
+            "setup": setup,               # optional imports/helpers (str or None)
+            "reference_code": reference,  # optional
         }
-
-        # Target can hold the reference code or be empty
-        target = reference if include_reference_in_target and isinstance(reference, str) else ""
 
         return Sample(
             id=task_id,
-            input=[user_msg],
-            target=target,
+            input=[ChatMessageUser(content=user_text)],
+            target="",
             metadata=metadata,
         )
 
     return _map
 
-
-def get_dataset(
-    config: str = "sanitized",
-    split: str = "test",
-    limit: Optional[int] = None,
-    instruction_prompt: str = MBPP_INSTRUCTION,
-    name: Optional[str] = None,
-) -> Dataset:
+def get_dataset(*, limit: Optional[int] = None, name: Optional[str] = None) -> Dataset:
     """
-    Load MBPP from Hugging Face.
-
-    Parameters: 
-        config : str
-            - "sanitized"  (fields: prompt, test_list, test_imports, code (often removed))
-            - "full" or "" (dataset default, fields vary but include test_list/test_setup_code)
-        split : str
-            Dataset split to load (e.g., "test", "validation", "train").
-        limit : Optional[int]
-            Max number of samples (useful for quick local runs).
-        instruction_prompt : str
-            Instruction prefix appended before each problem statement.
-        name : Optional[str]
-            Name for the resulting Dataset (defaults to "mbpp_<config>_<split>").
-
-    Returns:
-        Dataset
+    Load MBPP (sanitized) test split from Hugging Face and adapt to Inspect Samples.
     """
-    ds_name = name or f"mbpp_{config}_{split}".strip("_")
-
     return hf_dataset(
         path="Muennighoff/mbpp",
-        split=split,
-        sample_fields=record_to_sample(instruction_prompt=instruction_prompt),
+        name="sanitized",          # config, limited to sanitized
+        split="test",              # only split we use
+        sample_fields=record_to_sample(),
         limit=limit,
-        name=ds_name,
     )

--- a/src/openbench/datasets/mbpp.py
+++ b/src/openbench/datasets/mbpp.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from inspect_ai.dataset import Dataset, Sample, hf_dataset, FieldSpec
+from inspect_ai.model import ChatMessageUser
+
+MBPP_INSTRUCTION = """
+    You will be given a short Python programming task.
+    Write a single Python function that satisfies the prompt.
+    Your response should only contain the code for this function.
+    """.strip()
+
+# Normalize keys that commonly appear across MBPP variants.
+_TEST_LIST_KEYS = ("test_list", "challenge_test_list")
+_SETUP_KEYS = ("test_imports", "test_setup_code", "imports", "setup_code")
+_PROMPT_KEYS = ("prompt", "text", "task_description")
+_CODE_KEYS = ("code", "solution", "canonical_solution", "reference_code")
+
+
+def _get_first(record: Dict[str, Any], *candidates: str, default: Any = None) -> Any:
+    """Return the first present, non-empty value among candidate keys."""
+    for k in candidates:
+        if k in record and record[k] not in (None, ""):
+            return record[k]
+    return default
+
+
+def record_to_sample(
+    instruction_prompt: str = MBPP_INSTRUCTION,
+    include_reference_in_target: bool = True,
+) -> FieldSpec | Callable[[Dict[str, Any]], Sample]:
+    """
+    Mapper from MBPP records to Inspect Samples.
+
+    Parameters:
+        instruction_prompt : str
+            A prefix instruction prepended to the MBPP problem statement. This helps
+            constrain the model to emit a single function with no extra text.
+        include_reference_in_target : bool
+            If True, set `Sample.target` to the dataset's reference code (when available).
+            Scorers for code-exec usually don't *use* target, but it's handy for debugging.
+    """
+
+    def _map(record: Dict[str, Any]) -> Sample:
+        # Identify an ID if present (task_id is common in MBPP)
+        task_id = str(_get_first(record, "task_id", "id", default="")).strip() or None
+
+        # Problem statement (prompt)
+        prompt_text = str(_get_first(record, *_PROMPT_KEYS, default="")).strip()
+        if not prompt_text:
+            # Defensive: some variants may store the prompt under 'question'
+            prompt_text = str(record.get("question", "")).strip()
+
+        # Tests and optional setup/imports
+        # test_list is commonly a list[str] of assert statements
+        tests = _get_first(record, *_TEST_LIST_KEYS, default=None)
+        # test setup/imports may be a string block with imports or helper defs
+        setup = _get_first(record, *_SETUP_KEYS, default=None)
+
+        # Optional reference code (not executed by the scorer, but useful)
+        reference = _get_first(record, *_CODE_KEYS, default=None)
+
+        # Build the chat-style input: a single user message with instruction + prompt
+        user_msg = ChatMessageUser(content=f"{instruction_prompt}\n\n{prompt_text}".strip())
+
+        # Metadata that the scorer will use to assemble the harness
+        metadata: Dict[str, Any] = {
+            "task_id": task_id,
+            "prompt": prompt_text,
+            "tests": tests,                 # expected: list[str] of asserts (or None)
+            "setup": setup,                 # expected: str with imports/setup (or None)
+            "reference_code": reference,    # optional debugging aid
+        }
+
+        # Target can hold the reference code or be empty
+        target = reference if include_reference_in_target and isinstance(reference, str) else ""
+
+        return Sample(
+            id=task_id,
+            input=[user_msg],
+            target=target,
+            metadata=metadata,
+        )
+
+    return _map
+
+
+def get_dataset(
+    config: str = "sanitized",
+    split: str = "test",
+    limit: Optional[int] = None,
+    instruction_prompt: str = MBPP_INSTRUCTION,
+    name: Optional[str] = None,
+) -> Dataset:
+    """
+    Load MBPP from Hugging Face.
+
+    Parameters: 
+        config : str
+            - "sanitized"  (fields: prompt, test_list, test_imports, code (often removed))
+            - "full" or "" (dataset default, fields vary but include test_list/test_setup_code)
+        split : str
+            Dataset split to load (e.g., "test", "validation", "train").
+        limit : Optional[int]
+            Max number of samples (useful for quick local runs).
+        instruction_prompt : str
+            Instruction prefix appended before each problem statement.
+        name : Optional[str]
+            Name for the resulting Dataset (defaults to "mbpp_<config>_<split>").
+
+    Returns:
+        Dataset
+    """
+    ds_name = name or f"mbpp_{config}_{split}".strip("_")
+
+    return hf_dataset(
+        path="Muennighoff/mbpp",
+        split=split,
+        sample_fields=record_to_sample(instruction_prompt=instruction_prompt),
+        limit=limit,
+        name=ds_name,
+    )

--- a/src/openbench/evals/mbpp.py
+++ b/src/openbench/evals/mbpp.py
@@ -1,27 +1,10 @@
-# src/openbench/evals/mbpp.py
-"""
-MBPP (Mostly Basic Python Problems) evaluation for OpenBench (built on Inspect).
-
-Generates Python solutions for MBPP prompts and verifies them by executing
-unit tests inside a sandbox (Docker strongly recommended).
-
-Requires:
-  - datasets/mbpp.py   -> get_dataset(...)
-  - scorers/mbpp.py    -> mbpp_verify(...)
-
-CLI example:
-  bench eval mbpp --model openai/gpt-4o-mini --temperature 0 \
-    -T config=sanitized split=test limit=25 timeout=6 epochs=1 use_docker=true
-"""
-
 from __future__ import annotations
 
 from typing import Optional
 
-from inspect_ai import Task, task
+from inspect_ai import Task, task, Epochs
 from inspect_ai.model import GenerateConfig
 from inspect_ai.solver import generate
-from inspect_ai.util import Epochs
 
 from openbench.datasets.mbpp import get_dataset
 from openbench.scorers.mbpp import mbpp_verify
@@ -29,38 +12,17 @@ from openbench.scorers.mbpp import mbpp_verify
 
 @task
 def mbpp(
-    *,
-    # ---- Dataset controls ----
-    config: str = "sanitized",        # HF subset: "sanitized" or ""/"full"
-    split: str = "test",
     limit: Optional[int] = None,
-    instruction_prompt: Optional[str] = None,  # override adapter default if provided
 
-    # ---- Execution / scoring ----
+    # execution / scoring 
     timeout: int = 6,                 # seconds for python -c execution in sandbox
-    epochs: int = 1,                  # >1 approximates pass@k
+    epochs: int = 1,                  
     temperature: float = 0.0,         # determinism for code generation
 
 ) -> Task:
 
-    if instruction_prompt is None:
-        dataset = get_dataset(
-            config=config,
-            split=split,
-            limit=limit,
-            name=f"mbpp_{config}_{split}".strip("_"),
-        )
-    else:
-        dataset = get_dataset(
-            config=config,
-            split=split,
-            limit=limit,
-            instruction_prompt=instruction_prompt,      # custom instruction prompt
-            name=f"mbpp_{config}_{split}".strip("_"),
-        )
-    
     return Task(
-        dataset=dataset,
+        dataset=get_dataset(limit=limit),
         solver=generate(),
         scorer=mbpp_verify(timeout=timeout),
         sandbox="local",

--- a/src/openbench/evals/mbpp.py
+++ b/src/openbench/evals/mbpp.py
@@ -1,0 +1,70 @@
+# src/openbench/evals/mbpp.py
+"""
+MBPP (Mostly Basic Python Problems) evaluation for OpenBench (built on Inspect).
+
+Generates Python solutions for MBPP prompts and verifies them by executing
+unit tests inside a sandbox (Docker strongly recommended).
+
+Requires:
+  - datasets/mbpp.py   -> get_dataset(...)
+  - scorers/mbpp.py    -> mbpp_verify(...)
+
+CLI example:
+  bench eval mbpp --model openai/gpt-4o-mini --temperature 0 \
+    -T config=sanitized split=test limit=25 timeout=6 epochs=1 use_docker=true
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from inspect_ai import Task, task
+from inspect_ai.model import GenerateConfig
+from inspect_ai.solver import generate
+from inspect_ai.util import Epochs
+
+from openbench.datasets.mbpp import get_dataset
+from openbench.scorers.mbpp import mbpp_verify
+
+
+@task
+def mbpp(
+    *,
+    # ---- Dataset controls ----
+    config: str = "sanitized",        # HF subset: "sanitized" or ""/"full"
+    split: str = "test",
+    limit: Optional[int] = None,
+    instruction_prompt: Optional[str] = None,  # override adapter default if provided
+
+    # ---- Execution / scoring ----
+    timeout: int = 6,                 # seconds for python -c execution in sandbox
+    epochs: int = 1,                  # >1 approximates pass@k
+    temperature: float = 0.0,         # determinism for code generation
+
+) -> Task:
+
+    if instruction_prompt is None:
+        dataset = get_dataset(
+            config=config,
+            split=split,
+            limit=limit,
+            name=f"mbpp_{config}_{split}".strip("_"),
+        )
+    else:
+        dataset = get_dataset(
+            config=config,
+            split=split,
+            limit=limit,
+            instruction_prompt=instruction_prompt,      # custom instruction prompt
+            name=f"mbpp_{config}_{split}".strip("_"),
+        )
+    
+    return Task(
+        dataset=dataset,
+        solver=generate(),
+        scorer=mbpp_verify(timeout=timeout),
+        sandbox="local",
+        config=GenerateConfig(temperature=temperature),
+        epochs=Epochs(epochs),
+        name="mbpp",
+    )

--- a/src/openbench/evals/mbpp.py
+++ b/src/openbench/evals/mbpp.py
@@ -13,14 +13,11 @@ from openbench.scorers.mbpp import mbpp_verify
 @task
 def mbpp(
     limit: Optional[int] = None,
-
-    # execution / scoring 
-    timeout: int = 6,                 # seconds for python -c execution in sandbox
-    epochs: int = 1,                  
-    temperature: float = 0.0,         # determinism for code generation
-
+    # execution / scoring
+    timeout: int = 6,  # seconds for python -c execution in sandbox
+    epochs: int = 1,
+    temperature: float = 0.0,  # determinism for code generation
 ) -> Task:
-
     return Task(
         dataset=get_dataset(limit=limit),
         solver=generate(),

--- a/src/openbench/scorers/mbpp.py
+++ b/src/openbench/scorers/mbpp.py
@@ -1,0 +1,142 @@
+# src/openbench/scorers/mbpp.py
+import re
+from typing import Any, Callable, List, Optional
+
+from inspect_ai.scorer import (
+    Score,
+    Scorer,
+    Target,
+    accuracy,
+    CORRECT,
+    INCORRECT,
+    stderr,
+    scorer,
+)
+from inspect_ai.solver import TaskState
+from inspect_ai.util import ExecResult, sandbox
+
+TIMEOUT_DEFAULT = 6
+SENTINEL = "__MBPP_OK__"
+
+
+def find_code(completion: str) -> str:
+    """
+    Extract Python code from a completion. Prefer the first ```python fenced block,
+    else return the raw completion.
+    """
+    if not completion:
+        return ""
+    pattern = re.compile(r"```python\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+    matches = pattern.findall(completion)
+    extracted = matches[0] if matches else completion
+    return str(extracted).strip()
+
+
+def _normalize_tests(tests: Any) -> List[str]:
+    """Accept list[str] or str; return list[str] of test statements."""
+    if tests is None:
+        return []
+    if isinstance(tests, list):
+        return [t for t in (str(x).rstrip() for x in tests) if t]
+    if isinstance(tests, str):
+        return [ln.rstrip() for ln in tests.splitlines() if ln.strip()]
+    return []
+
+
+def _assemble_program(
+    *,
+    setup: Optional[str],
+    candidate_code: str,
+    tests: List[str],
+    add_sentinel: bool = True,
+) -> str:
+    parts: List[str] = []
+    if setup and setup.strip():
+        parts.append(setup.strip())
+    parts.append(candidate_code.strip())
+    if tests:
+        parts.append("\n".join(tests))
+    if add_sentinel:
+        parts.append(f'print("{SENTINEL}")')
+    return "\n\n".join(parts)
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def mbpp_verify(timeout: int = TIMEOUT_DEFAULT, require_sentinel: bool = True) -> Scorer:
+    """
+    Execute model-generated MBPP solutions and unit tests inside the sandbox.
+
+    - Builds one Python program: [setup] + [candidate] + [tests] + sentinel
+    - Runs: python -c "<program>"
+    - Pass iff exit code == 0 and (optionally) sentinel appears in stdout.
+    """
+
+    async def score(state: TaskState, target: Target) -> Score:
+        md = state.metadata or {}
+        task_id = md.get("task_id")
+        prompt = md.get("prompt", "")
+        setup = md.get("setup")
+        tests = _normalize_tests(md.get("tests"))
+
+        # 1) Extract candidate in HumanEval style
+        raw = state.output.completion if state.output else ""
+        candidate = find_code(raw)
+
+        # Guard rail: empty candidate
+        if not candidate.strip():
+            prog = _assemble_program(setup=setup, candidate_code="", tests=tests, add_sentinel=True)
+            explanation = (
+                "No candidate code found.\n\n"
+                "The following verification code was executed:\n\n```python\n"
+                + prog + "\n```\n"
+            )
+            return Score(value=INCORRECT, answer="", explanation=explanation, metadata={"task_id": task_id})
+
+        # 2) Assemble the verification program
+        program = _assemble_program(setup=setup, candidate_code=candidate, tests=tests, add_sentinel=True)
+
+        # 3) Execute in sandbox
+        try:
+            result = await sandbox().exec(
+                cmd=["python", "-c", program],
+                timeout=timeout,
+            )
+        except TimeoutError:
+            result = ExecResult(False, 1, "", "Verification timed out.")
+        except Exception as e:
+            result = ExecResult(False, 1, "", f"{type(e).__name__}: {e}")
+
+        # 4) Decide pass/fail
+        passed = bool(result.success) and ((SENTINEL in (result.stdout or "")) if require_sentinel else True)
+        value = CORRECT if passed else INCORRECT
+
+        # 5) HumanEval-like explanation blob (show exactly what ran)
+        explanation_parts = [
+            "The following verification code was executed:\n\n```python\n",
+            program,
+            "\n```\n",
+        ]
+        if not passed:
+            explanation_parts.extend(
+                [
+                    "The submission was incorrect.\n\n",
+                    (result.stderr or ""),
+                ]
+            )
+        explanation = "".join(explanation_parts)
+
+        return Score(
+            value=value,
+            answer=candidate,
+            explanation=explanation,
+            metadata={
+                "task_id": task_id,
+                "prompt": prompt,
+                "tests_count": len(tests),
+                "timeout_s": timeout,
+                "exit_success": bool(result.success),
+                "sentinel_seen": (SENTINEL in (result.stdout or "")) if require_sentinel else None,
+            },
+        )
+
+    return score

--- a/src/openbench/scorers/mbpp.py
+++ b/src/openbench/scorers/mbpp.py
@@ -1,74 +1,96 @@
 # src/openbench/scorers/mbpp.py
+"""
+MBPP verifier for OpenBench (Inspect), aligned with the paper-style prompt:
+
+You are an expert Python programmer, and here is your task: {prompt}
+Your code should pass these tests:
+
+{tests}
+[BEGIN]
+{code}
+[DONE]
+
+Scoring policy:
+  1) Assemble one Python program:
+       [optional setup/imports]
+       [candidate code extracted from the completion]
+       [unit tests (assert statements)]
+       print("__MBPP_OK__")
+  2) Run: python -c "<assembled>"
+  3) Pass iff exit code == 0 
+"""
+
+from __future__ import annotations
+
 import re
 from typing import Any, Callable, List, Optional
-
-from inspect_ai.scorer import (
-    Score,
-    Scorer,
-    Target,
-    accuracy,
-    CORRECT,
-    INCORRECT,
-    stderr,
-    scorer,
-)
 from inspect_ai.solver import TaskState
+from inspect_ai.scorer import scorer, Score, Target, accuracy, stderr, CORRECT, INCORRECT
 from inspect_ai.util import ExecResult, sandbox
 
-TIMEOUT_DEFAULT = 6
-SENTINEL = "__MBPP_OK__"
 
+# code extraction logic
 
-def find_code(completion: str) -> str:
+_BEGIN_DONE_RE = re.compile(r"\[BEGIN\](?P<code>[\s\S]*?)\[DONE\]", re.IGNORECASE)
+_FENCED_RE = re.compile(r"```(?:python|py)?\s*(?P<code>[\s\S]*?)```", re.IGNORECASE)
+
+def _extract_code(completion: str) -> str:
     """
-    Extract Python code from a completion. Prefer the first ```python fenced block,
-    else return the raw completion.
+    Extract Python code in priority order:
+      1) [BEGIN] ... [DONE]
+      2) ```python fenced code```
+      3) raw completion
     """
     if not completion:
         return ""
-    pattern = re.compile(r"```python\s*(.*?)```", re.DOTALL | re.IGNORECASE)
-    matches = pattern.findall(completion)
-    extracted = matches[0] if matches else completion
-    return str(extracted).strip()
+    m = _BEGIN_DONE_RE.search(completion)
+    if m:
+        return m.group("code").strip()
+    m = _FENCED_RE.search(completion)
+    if m:
+        return m.group("code").strip()
+    return completion.strip()
 
+
+# utils
 
 def _normalize_tests(tests: Any) -> List[str]:
-    """Accept list[str] or str; return list[str] of test statements."""
+    """Accept list[str] or str; return list[str] of statements (asserts)."""
     if tests is None:
         return []
     if isinstance(tests, list):
-        return [t for t in (str(x).rstrip() for x in tests) if t]
+        return [s for s in (str(x).rstrip() for x in tests) if s]
     if isinstance(tests, str):
         return [ln.rstrip() for ln in tests.splitlines() if ln.strip()]
     return []
-
 
 def _assemble_program(
     *,
     setup: Optional[str],
     candidate_code: str,
     tests: List[str],
-    add_sentinel: bool = True,
 ) -> str:
+    """Order: setup -> candidate_code -> tests"""
     parts: List[str] = []
     if setup and setup.strip():
         parts.append(setup.strip())
     parts.append(candidate_code.strip())
     if tests:
         parts.append("\n".join(tests))
-    if add_sentinel:
-        parts.append(f'print("{SENTINEL}")')
     return "\n\n".join(parts)
+
+def _truncate(s: str, n: int = 1200) -> str:
+    return s if len(s) <= n else s[: n - 3] + "..."
 
 
 @scorer(metrics=[accuracy(), stderr()])
-def mbpp_verify(timeout: int = TIMEOUT_DEFAULT, require_sentinel: bool = True) -> Scorer:
+def mbpp_verify(*, timeout: int = 6) -> Callable[[TaskState, Target], Score]:
     """
-    Execute model-generated MBPP solutions and unit tests inside the sandbox.
+    Execute model-generated MBPP solutions and unit tests inside the current sandbox.
 
-    - Builds one Python program: [setup] + [candidate] + [tests] + sentinel
-    - Runs: python -c "<program>"
-    - Pass iff exit code == 0 and (optionally) sentinel appears in stdout.
+    Parameters:
+        timeout : int
+            Seconds allowed for python -c execution.
     """
 
     async def score(state: TaskState, target: Target) -> Score:
@@ -78,24 +100,23 @@ def mbpp_verify(timeout: int = TIMEOUT_DEFAULT, require_sentinel: bool = True) -
         setup = md.get("setup")
         tests = _normalize_tests(md.get("tests"))
 
-        # 1) Extract candidate in HumanEval style
+        # extract candidate code from completion
         raw = state.output.completion if state.output else ""
-        candidate = find_code(raw)
+        candidate = _extract_code(raw)
 
-        # Guard rail: empty candidate
-        if not candidate.strip():
-            prog = _assemble_program(setup=setup, candidate_code="", tests=tests, add_sentinel=True)
+        if not candidate:
+            program = _assemble_program(setup=setup, candidate_code="", tests=tests)
             explanation = (
                 "No candidate code found.\n\n"
                 "The following verification code was executed:\n\n```python\n"
-                + prog + "\n```\n"
+                + program + "\n```\n"
             )
             return Score(value=INCORRECT, answer="", explanation=explanation, metadata={"task_id": task_id})
 
-        # 2) Assemble the verification program
-        program = _assemble_program(setup=setup, candidate_code=candidate, tests=tests, add_sentinel=True)
+        # assemble program
+        program = _assemble_program(setup=setup, candidate_code=candidate, tests=tests)
 
-        # 3) Execute in sandbox
+        # execute in sandbox (task defaults to 'local')
         try:
             result = await sandbox().exec(
                 cmd=["python", "-c", program],
@@ -106,24 +127,19 @@ def mbpp_verify(timeout: int = TIMEOUT_DEFAULT, require_sentinel: bool = True) -
         except Exception as e:
             result = ExecResult(False, 1, "", f"{type(e).__name__}: {e}")
 
-        # 4) Decide pass/fail
-        passed = bool(result.success) and ((SENTINEL in (result.stdout or "")) if require_sentinel else True)
+        # decide pass/fail
+        passed = bool(result.success)
         value = CORRECT if passed else INCORRECT
 
-        # 5) HumanEval-like explanation blob (show exactly what ran)
-        explanation_parts = [
+        # explanation (show exactly what ran; include stderr on failure)
+        parts = [
             "The following verification code was executed:\n\n```python\n",
             program,
             "\n```\n",
         ]
         if not passed:
-            explanation_parts.extend(
-                [
-                    "The submission was incorrect.\n\n",
-                    (result.stderr or ""),
-                ]
-            )
-        explanation = "".join(explanation_parts)
+            parts.extend(["The submission was incorrect.\n\n", (result.stderr or "")])
+        explanation = "".join(parts)
 
         return Score(
             value=value,
@@ -131,11 +147,10 @@ def mbpp_verify(timeout: int = TIMEOUT_DEFAULT, require_sentinel: bool = True) -
             explanation=explanation,
             metadata={
                 "task_id": task_id,
-                "prompt": prompt,
+                "prompt": _truncate(str(prompt), 400),
                 "tests_count": len(tests),
                 "timeout_s": timeout,
-                "exit_success": bool(result.success),
-                "sentinel_seen": (SENTINEL in (result.stdout or "")) if require_sentinel else None,
+                "exit_success": passed,
             },
         )
 

--- a/src/openbench/scorers/mbpp.py
+++ b/src/openbench/scorers/mbpp.py
@@ -17,7 +17,7 @@ Scoring policy:
        [unit tests (assert statements)]
        print("__MBPP_OK__")
   2) Run: python -c "<assembled>"
-  3) Pass iff exit code == 0 
+  3) Pass iff exit code == 0
 """
 
 from __future__ import annotations
@@ -25,7 +25,15 @@ from __future__ import annotations
 import re
 from typing import Any, Callable, List, Optional
 from inspect_ai.solver import TaskState
-from inspect_ai.scorer import scorer, Score, Target, accuracy, stderr, CORRECT, INCORRECT
+from inspect_ai.scorer import (
+    scorer,
+    Score,
+    Target,
+    accuracy,
+    stderr,
+    CORRECT,
+    INCORRECT,
+)
 from inspect_ai.util import ExecResult, sandbox
 
 
@@ -33,6 +41,7 @@ from inspect_ai.util import ExecResult, sandbox
 
 _BEGIN_DONE_RE = re.compile(r"\[BEGIN\](?P<code>[\s\S]*?)\[DONE\]", re.IGNORECASE)
 _FENCED_RE = re.compile(r"```(?:python|py)?\s*(?P<code>[\s\S]*?)```", re.IGNORECASE)
+
 
 def _extract_code(completion: str) -> str:
     """
@@ -54,6 +63,7 @@ def _extract_code(completion: str) -> str:
 
 # utils
 
+
 def _normalize_tests(tests: Any) -> List[str]:
     """Accept list[str] or str; return list[str] of statements (asserts)."""
     if tests is None:
@@ -63,6 +73,7 @@ def _normalize_tests(tests: Any) -> List[str]:
     if isinstance(tests, str):
         return [ln.rstrip() for ln in tests.splitlines() if ln.strip()]
     return []
+
 
 def _assemble_program(
     *,
@@ -78,6 +89,7 @@ def _assemble_program(
     if tests:
         parts.append("\n".join(tests))
     return "\n\n".join(parts)
+
 
 def _truncate(s: str, n: int = 1200) -> str:
     return s if len(s) <= n else s[: n - 3] + "..."
@@ -109,9 +121,15 @@ def mbpp_verify(*, timeout: int = 6) -> Callable[[TaskState, Target], Score]:
             explanation = (
                 "No candidate code found.\n\n"
                 "The following verification code was executed:\n\n```python\n"
-                + program + "\n```\n"
+                + program
+                + "\n```\n"
             )
-            return Score(value=INCORRECT, answer="", explanation=explanation, metadata={"task_id": task_id})
+            return Score(
+                value=INCORRECT,
+                answer="",
+                explanation=explanation,
+                metadata={"task_id": task_id},
+            )
 
         # assemble program
         program = _assemble_program(setup=setup, candidate_code=candidate, tests=tests)


### PR DESCRIPTION
## Summary

Adds support for evaluating MBPP (Mostly Basic Python Problems) tasks in OpenBench using sandbox execution. Enables benchmarking code generation models on a dataset of ~1,000 entry-level Python programming problems (incl. task description, canonical solution, and automated unit tests).

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

- Added datasets/mbpp.py adapter:
    - Loads the sanitized MBPP split from Hugging Face
    - Normalizes fields (prompt, test_list, test_imports, code) 
    - Constructs user prompts following the paper format

- Added scorers/mbpp.py:
    - Extracts candidate code from completions
    - Assembles a runnable Python program
    - Executes in a local sandbox; passing = exit code == 0.

- Added evals/mbpp.py:
    - Defines an Inspect Task for MBPP.
    - Supports configurable dataset config (default: sanitized).
    - Defaults to local sandbox execution.
- Added benchmark metadata entry for MBPP.

## Testing

<!-- Describe how you tested your changes -->
- [X] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [ ] I have tested with multiple model providers (if applicable)
- [X] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

## Additional Context

This implementation mirrors HumanEval but is tailored to MBPP’s sanitized split. The dataset adapter is currently restricted to "sanitized" data for consistency. Future extensions could support the full config or alternative variants.