### PR TITLE
feat: add BrowseComp benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,6 @@ dev = [
     "pytest-asyncio==0.24.0",
     "pytest-cov>=4.1.0",
     "ruff>=0.11.9",
-    "types-jsonschema==4.23.0.20240813",
+    "types-jsonschema>=4.0.0",
     "types-pyyaml>=6.0.12.20250809",
 ]

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -193,6 +193,14 @@ BENCHMARKS = {
         module_path="openbench.evals.simpleqa",
         function_name="simpleqa",
     ),
+    "browsecomp": BenchmarkMetadata(
+        name="BrowseComp",
+        description="A Simple Yet Challenging Benchmark for Browsing Agents - evaluates model performance on browsing-related tasks",
+        category="core",
+        tags=["browsing", "web", "reasoning", "graded"],
+        module_path="openbench.evals.browsecomp",
+        function_name="browsecomp",
+    ),
     "hle": BenchmarkMetadata(
         name="Humanity's Last Exam",
         description="Multi-modal benchmark at the frontier of human knowledge - 2,500 questions across mathematics, humanities, and natural sciences designed by subject-matter experts globally",

--- a/src/openbench/datasets/browsecomp.py
+++ b/src/openbench/datasets/browsecomp.py
@@ -1,0 +1,68 @@
+"""Dataset loader for BrowseComp: A Simple Yet Challenging Benchmark for Browsing Agents.
+
+https://openai.com/index/browsecomp/
+"""
+
+import base64
+import hashlib
+from inspect_ai.dataset import Dataset, csv_dataset, Sample, MemoryDataset
+
+
+def derive_key(password: str, length: int) -> bytes:
+    """Derive a fixed-length key from the password using SHA256."""
+    hasher = hashlib.sha256()
+    hasher.update(password.encode())
+    key = hasher.digest()
+    return key * (length // len(key)) + key[: length % len(key)]
+
+
+def decrypt(ciphertext_b64: str, password: str) -> str:
+    """Decrypt base64-encoded ciphertext with XOR."""
+    encrypted = base64.b64decode(ciphertext_b64)
+    key = derive_key(password, len(encrypted))
+    decrypted = bytes(a ^ b for a, b in zip(encrypted, key))
+    return decrypted.decode()
+
+
+def record_to_sample(record: dict) -> Sample:
+    """Convert a BrowseComp CSV record to an Inspect Sample."""
+    # Decrypt the problem and answer using the canary
+    problem = decrypt(record.get("problem", ""), record.get("canary", ""))
+    answer = decrypt(record.get("answer", ""), record.get("canary", ""))
+
+    # Format the input with the query template
+    formatted_input = f"""{problem}
+
+Your response should be in the following format:
+Explanation: {{your explanation for your final answer}}
+Exact Answer: {{your succinct, final answer}}
+Confidence: {{your confidence score between 0% and 100% for your answer}}"""
+
+    return Sample(
+        input=formatted_input,
+        target=answer,
+        metadata={
+            "canary": record.get("canary", ""),
+            "plain_question": problem,  # Store the plain question for the grader
+        },
+    )
+
+
+def get_dataset() -> Dataset:
+    """Load the BrowseComp dataset.
+
+    Returns:
+        Dataset containing BrowseComp samples
+    """
+    # Load the full dataset
+    dataset = csv_dataset(
+        csv_file="https://openaipublic.blob.core.windows.net/simple-evals/browse_comp_test_set.csv",
+        sample_fields=record_to_sample,
+        auto_id=True,
+        name="browsecomp",
+    )
+
+    # Convert to list of samples
+    samples = list(dataset)
+
+    return MemoryDataset(samples=samples, name="browsecomp")

--- a/src/openbench/evals/browsecomp.py
+++ b/src/openbench/evals/browsecomp.py
@@ -1,0 +1,33 @@
+"""BrowseComp: A Simple Yet Challenging Benchmark for Browsing Agents.
+
+Authors: Jason Wei, Zhiqing Sun, Spencer Papay, Scott McKinney, Jeffrey Han,
+Isa Fulford, Hyung Won Chung, Alex Tachard Passos, William Fedus, Mia Glaese
+
+https://openai.com/index/browsecomp/
+"""
+
+from inspect_ai import task, Task
+from inspect_ai.solver import generate
+from openbench.datasets.browsecomp import get_dataset
+from openbench.scorers.browsecomp import browsecomp_scorer
+
+
+@task
+def browsecomp(grader_model: str = "openai/gpt-4.1-2025-04-14") -> Task:
+    """BrowseComp: A Simple Yet Challenging Benchmark for Browsing Agents.
+
+    This benchmark evaluates model performance on browsing-related tasks
+    that require understanding and reasoning about web content.
+
+    Args:
+        grader_model: Model to use for grading responses (defaults to gpt-4.1-2025-04-14)
+
+    Returns:
+        Task configured for BrowseComp evaluation
+    """
+    return Task(
+        dataset=get_dataset(),
+        solver=[generate()],
+        scorer=browsecomp_scorer(model=grader_model),
+        name="browsecomp",
+    )

--- a/src/openbench/scorers/browsecomp.py
+++ b/src/openbench/scorers/browsecomp.py
@@ -1,0 +1,108 @@
+"""Scorer for BrowseComp evaluation."""
+
+import re
+from typing import Callable
+from inspect_ai.scorer import (
+    accuracy,
+    scorer,
+    stderr,
+    Score,
+    Target,
+)
+from inspect_ai.solver import TaskState
+from inspect_ai.model import get_model, ChatMessageUser, Model
+
+
+# Grading template from the original BrowseComp implementation
+GRADER_TEMPLATE = """
+Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
+
+[question]: {question}
+
+[response]: {response}
+
+Your judgement must be in the format and criteria specified below:
+
+extracted_final_answer: The final exact answer extracted from the [response]. Put the extracted answer as 'None' if there is no exact, final answer to extract from the response.
+
+[correct_answer]: {correct_answer}
+
+reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer], focusing only on if there are meaningful differences between [correct_answer] and the extracted_final_answer. Do not comment on any background to the problem, do not attempt to solve the problem, do not argue for any answer different than [correct_answer], focus only on whether the answers match.
+
+correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] given above, or is within a small margin of error for numerical problems. Answer 'no' otherwise, i.e. if there if there is any inconsistency, ambiguity, non-equivalency, or if the extracted answer is incorrect.
+
+
+confidence: The extracted confidence score between 0|%| and 100|%| from [response]. Put 100 if there is no confidence score available.
+""".strip()
+
+
+# Query template from the original BrowseComp implementation
+QUERY_TEMPLATE = """
+{Question}
+
+Your response should be in the following format:
+Explanation: {{your explanation for your final answer}}
+Exact Answer: {{your succinct, final answer}}
+Confidence: {{your confidence score between 0% and 100% for your answer}}
+""".strip()
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def browsecomp_scorer(model: str = "openai/gpt-4.1-2025-04-14") -> Callable:
+    """BrowseComp scorer using model grading.
+
+    Args:
+        model: Model to use for grading responses (defaults to gpt-4.1-2025-04-14)
+
+    Returns:
+        Scorer function for BrowseComp evaluation
+    """
+    grader_model: Model = get_model(model)
+
+    async def score(state: TaskState, target: Target) -> Score:
+        # Get the plain question from metadata (not the formatted input)
+        # This matches the simple-evals implementation where the grader gets the plain question
+        question = state.metadata.get("plain_question", state.input_text)
+
+        # Get the predicted answer from the model output
+        predicted_answer = state.output.completion
+
+        # Format the grading prompt
+        grader_prompt = GRADER_TEMPLATE.format(
+            question=question,
+            correct_answer=target.text,
+            response=predicted_answer,
+        )
+
+        # Create the message for grading
+        message = ChatMessageUser(content=grader_prompt)
+
+        # Get grading response
+        grading_response = await grader_model.generate([message])
+        grading_text = grading_response.completion
+
+        # Extract whether the answer is correct
+        # Look for "correct: yes" or "correct: no" in the response
+        match = re.search(r"correct:\s*(yes|no)", grading_text, re.IGNORECASE)
+        is_correct = match.group(1).lower() == "yes" if match else False
+
+        # Extract confidence if available
+        confidence_match = re.search(
+            r"confidence:\s*(\d+)(?:\s*%)?", grading_text, re.IGNORECASE
+        )
+        confidence = (
+            int(confidence_match.group(1)) if confidence_match else 100
+        )  # Default to 100 if not found
+
+        # Return score with metadata
+        return Score(
+            value=1.0 if is_correct else 0.0,
+            answer=predicted_answer,
+            metadata={
+                "is_correct": is_correct,
+                "confidence": confidence,
+                "grading_response": grading_text,
+            },
+        )
+
+    return score

--- a/src/openbench/scorers/browsecomp.py
+++ b/src/openbench/scorers/browsecomp.py
@@ -84,14 +84,18 @@ def browsecomp_scorer(model: str = "openai/gpt-4.1-2025-04-14") -> Callable:
         # Extract whether the answer is correct
         # Look for "correct: yes" or "correct: no" in the response
         match = re.search(r"correct:\s*(yes|no)", grading_text, re.IGNORECASE)
-        is_correct = match.group(1).lower() == "yes" if match else False
+        is_correct = (
+            (match.group(1).lower() == "yes") if (match and match.group(1)) else False
+        )
 
         # Extract confidence if available
         confidence_match = re.search(
             r"confidence:\s*(\d+)(?:\s*%)?", grading_text, re.IGNORECASE
         )
         confidence = (
-            int(confidence_match.group(1)) if confidence_match else 100
+            int(confidence_match.group(1))
+            if (confidence_match and confidence_match.group(1))
+            else 100
         )  # Default to 100 if not found
 
         # Return score with metadata

--- a/uv.lock
+++ b/uv.lock
@@ -2070,6 +2070,7 @@ dependencies = [
     { name = "datasets" },
     { name = "groq" },
     { name = "inspect-ai" },
+    { name = "jsonschema" },
     { name = "openai" },
     { name = "pydantic-settings" },
     { name = "scicode" },
@@ -2083,8 +2084,10 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
     { name = "types-pyyaml" },
 ]
 
@@ -2093,6 +2096,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=3.6.0" },
     { name = "groq", specifier = ">=0.30.0" },
     { name = "inspect-ai", specifier = "==0.3.115" },
+    { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "openai", specifier = ">=1.97.1" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "scicode", git = "https://github.com/TheFloatingString/SciCode-fork.git?rev=4f20d721ba3e2227196262083b9b7a70484d54f7" },
@@ -2106,8 +2110,10 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = "==0.24.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.11.9" },
+    { name = "types-jsonschema", specifier = ">=4.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250809" },
 ]
 
@@ -2666,6 +2672,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855, upload-time = "2024-08-22T08:03:18.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024, upload-time = "2024-08-22T08:03:15.536Z" },
 ]
 
 [[package]]
@@ -3319,6 +3337,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/1a/5f36851f439884bcfe8539f6a20ff7516e7b60f319bbaf69a90dc35cc2eb/typer-0.15.3.tar.gz", hash = "sha256:818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c", size = 101641, upload-time = "2025-04-28T21:40:59.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/20/9d953de6f4367163d23ec823200eb3ecb0050a2609691e512c8b95827a9b/typer-0.15.3-py3-none-any.whl", hash = "sha256:c86a65ad77ca531f03de08d1b9cb67cd09ad02ddddf4b34745b5008f43b239bd", size = 45253, upload-time = "2025-04-28T21:40:56.269Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.25.1.20250821"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/7b/bd0a0f942beec6a4540c604a1a9f1c52a82f6fb0d915c6b2f8810bbd5590/types_jsonschema-4.25.1.20250821.tar.gz", hash = "sha256:4a2d744a3dd284d2b13423466d7584917bb050c493ac09e1a361d4feed92aaed", size = 15511, upload-time = "2025-08-21T03:01:52.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/b8/c92fa726786f503a95b02033f1739404c49db9d2a7b56ff50207a22cdb9a/types_jsonschema-4.25.1.20250821-py3-none-any.whl", hash = "sha256:73e22048556bfd097d58883b203ff298a2dbece0d76b35115dbee0dad9b02bab", size = 15798, upload-time = "2025-08-21T03:01:50.848Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements BrowseComp (A Simple Yet Challenging Benchmark for Browsing Agents) from [simple-evals](https://github.com/openai/simple-evals)
- Adds comprehensive browsing-related benchmark with 1,266 questions that evaluate model performance on web content understanding and reasoning tasks
- Fixes a bug in the original simple-evals implementation (regex extraction issue)

## Implementation Details

### Components Added
1. **Dataset Loader** (`src/openbench/datasets/browsecomp.py`)
   - Loads encrypted dataset from OpenAI's public blob storage
   - Implements XOR decryption for questions and answers using canary values
   - Formats questions with required response template

2. **Scorer** (`src/openbench/scorers/browsecomp.py`)
   - Model-graded scoring using gpt-4.1-2025-04-14 by default
   - Preserves exact grading template from original implementation
   - Fixes regex bug: uses `match.group(1)` instead of `match.group(0)` for correct extraction

3. **Evaluation Task** (`src/openbench/evals/browsecomp.py`)
   - Simple task configuration following OpenBench patterns
   - Configurable grader model

4. **Configuration** (`src/openbench/config.py`)
   - Registered as core benchmark with appropriate tags

### Additional Changes
- Added `types-jsonschema` dev dependency to fix mypy type checking issues

## Testing
```bash
# List benchmarks to verify registration
bench list | grep -i browse

# View benchmark details
bench describe browsecomp

# Run evaluation
bench eval browsecomp --model openai/gpt-4o --limit 10
```

## Notes
- BrowseComp is a challenging benchmark - expect lower accuracy scores even with strong models
- The original paper/blog post: https://openai.com/index/browsecomp/
- Dataset contains browsing-related questions requiring web content understanding