### PR TITLE
fix: handle skipped integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
-          uv run pytest -m "not integration" --cov=bench --cov-report=term-missing
+          uv run pytest -m "not integration" --cov=openbench --cov-report=term-missing
 
   integration-test:
     name: Integration Tests
@@ -143,10 +143,19 @@ jobs:
     steps:
       - name: Verify all checks passed
         run: |
+          # Quality checks and test must always pass
           if [[ "${{ needs.quality-checks.result }}" != "success" || 
-                "${{ needs.test.result }}" != "success" || 
-                "${{ needs.integration-test.result }}" != "success" ]]; then
+                "${{ needs.test.result }}" != "success" ]]; then
             echo "One or more required checks failed"
             exit 1
           fi
-          echo "All checks passed!"
+          
+          # Integration test can be skipped (for external PRs) or must succeed
+          if [[ "${{ needs.integration-test.result }}" != "success" && 
+                "${{ needs.integration-test.result }}" != "skipped" ]]; then
+            echo "Integration tests failed"
+            exit 1
+          fi
+          
+          # Security is continue-on-error, so we don't check it
+          echo "All required checks passed!"


### PR DESCRIPTION
## Summary
- Fix "All Checks Pass" job to properly handle skipped integration tests for external PRs
- Fix test coverage path from incorrect 'bench' to correct 'openbench' package name

## Problem
The CI was incorrectly failing when integration tests were skipped (which happens for external contributors' PRs from forks). This made it appear that external PRs were failing CI when they were actually fine.

## Solution
- Updated the "All Checks Pass" job logic to treat skipped integration tests as acceptable
- Fixed the pytest coverage path to use the correct package name 'openbench' instead of 'bench'

## Test plan
- [x] CI should now pass for external PRs that have skipped integration tests
- [x] Test coverage should now correctly report coverage for the openbench package