### PR TITLE
fix(rootly_gmcq): handle both string and list content types in scorer

### DIFF
--- a/src/openbench/scorers/rootly_gmcq.py
+++ b/src/openbench/scorers/rootly_gmcq.py
@@ -5,7 +5,19 @@ from inspect_ai.solver import TaskState
 @scorer(metrics=[accuracy(), stderr()])
 def custom_scorer():
     async def score(state: TaskState, target: Target) -> Score:
-        if state.messages[-1].content.strip().upper() == target.target[0]:  # type: ignore
+        # Get the text content from the last message
+        last_message = state.messages[-1]
+
+        # Handle both string and list content types
+        if isinstance(last_message.content, str):
+            answer = last_message.content.strip().upper()
+        elif isinstance(last_message.content, list):
+            # Use the text property which properly concatenates text content
+            answer = last_message.text.strip().upper()
+        else:
+            answer = ""
+
+        if answer == target.target[0]:
             return Score(value=1.0)
         else:
             return Score(value=0.0)


### PR DESCRIPTION
## Summary
- Fixed AttributeError in rootly_gmcq scorer when message content is a list
- Added proper handling for both string and list content types using the .text property

## Test plan
- [x] Tested with `bench eval rootly_gmcq --model groq/openai/gpt-oss-20b --limit 5`
- [x] Evaluation runs successfully without AttributeError
- [x] Scorer correctly extracts answer from both content types