### PR TITLE
feat: configure release-please for pre-v1.0 version bumping

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,8 @@
         "include-v-in-tag": true,
         "include-component-in-tag": false,
         "changelog-path": "CHANGELOG.md",
+        "bump-minor-pre-major": false,
+        "bump-patch-for-minor-pre-major": true,
         "extra-files": [
           {
             "type": "toml",


### PR DESCRIPTION
## Summary
Configure release-please to only increment minor version on breaking changes before v1.0.0.

- Set `bump-minor-pre-major: false` to prevent regular features from bumping minor version
- Set `bump-patch-for-minor-pre-major: true` to make features bump patch version instead

## Behavior Changes
**Before v1.0.0:**
- `feat:` commits → patch version bump (was minor)  
- `fix:` commits → patch version bump (unchanged)
- `feat!:`/`fix!:` commits → minor version bump (was major)

**After v1.0.0:**
- Standard semver behavior applies (`feat:` → minor, `feat!:` → major)

## Test plan
- [ ] Verify configuration syntax is valid
- [ ] Test with next release to confirm version bumping behavior
- [ ] Monitor that breaking changes still properly increment versions