### PR TITLE
feat: change default model to groq/openai/gpt-oss-20b

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ export HF_TOKEN=your_key
 export OPENAI_API_KEY=your_key  # Optional
 
 # Set default model
-export BENCH_MODEL=groq/llama-3.1-70b
+export BENCH_MODEL=groq/openai/gpt-oss-20b
 ```
 
 ## Commands and Options
@@ -161,7 +161,7 @@ For a complete list of all commands and options, run: `bench --help`
 | -------------------- | ------------------------ | --------------- | ---------------------------------------------------------------- |
 | `-M <args>`          | None                     | None            | Pass model-specific arguments (e.g., `-M reasoning_effort=high`) |
 | `-T <args>`          | None                     | None            | Pass task-specific arguments to the benchmark                    |
-| `--model`            | `BENCH_MODEL`            | None (required) | Model(s) to evaluate                                             |
+| `--model`            | `BENCH_MODEL`            | `groq/openai/gpt-oss-20b` | Model(s) to evaluate                                             |
 | `--epochs`           | `BENCH_EPOCHS`           | `1`             | Number of epochs to run each evaluation                          |
 | `--max-connections`  | `BENCH_MAX_CONNECTIONS`  | `10`            | Maximum parallel requests to model                               |
 | `--temperature`      | `BENCH_TEMPERATURE`      | `0.6`           | Model temperature                                                |

--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -124,7 +124,7 @@ def run_eval(
             help="Model(s) to evaluate. Equivalent to --model-role candidate=<model>",
             envvar="BENCH_MODEL",
         ),
-    ] = ["groq/meta-llama/llama-4-scout-17b-16e-instruct"],
+    ] = ["groq/openai/gpt-oss-20b"],
     max_connections: Annotated[
         Optional[int],
         typer.Option(


### PR DESCRIPTION
## Summary

- Changes the default model from `groq/meta-llama/llama-4-scout-17b-16e-instruct` to `groq/openai/gpt-oss-20b`
- Updates CLI default in `src/openbench/_cli/eval_command.py`
- Updates documentation in README.md to reflect the new default in both configuration examples and CLI options table

## Test plan

- [x] Verified CLI help shows new default model
- [x] Confirmed basic CLI functionality still works
- [x] Pre-commit hooks pass (ruff check, ruff format, mypy)