### PR TITLE
ci: remove PR trigger from release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -3,8 +3,6 @@ name: Release Please
 on:
   push:
     branches: [ main ]
-  pull_request:
-      branches: [ main ]
 
 permissions:
   contents: write   # allow tagging and releases


### PR DESCRIPTION
Remove the 'pull_request' trigger from .github/workflows/release-please.yaml. This reduces redundant runs and relies on push to main + release PR merges.