### PR TITLE
feat(openrouter): add provider routing args support

### DIFF
--- a/src/openbench/model/_providers/openrouter.py
+++ b/src/openbench/model/_providers/openrouter.py
@@ -12,13 +12,25 @@ Model naming follows the standard format, e.g.:
   - anthropic/claude-sonnet-4.1
   - deepseek/deepseek-chat-v3.1
 
+Provider routing parameters can be specified to control which providers are used:
+  - only: Restrict to specific providers (e.g., only=groq or only=cerebras,openai)
+  - order: Provider priority order (e.g., order=openai,anthropic)
+  - allow_fallbacks: Enable/disable fallback providers (boolean)
+  - ignore: Providers to skip (e.g., ignore=cerebras,fireworks)
+  - sort: Sort providers by "price" or "throughput"
+  - max_price: Maximum price limits (e.g., max_price={"completion": 0.01})
+  - quantizations: Filter by quantization levels (e.g., quantizations=int4,int8)
+  - require_parameters: Require parameter support (boolean)
+  - data_collection: Data collection setting ("allow" or "deny")
+
 Website: https://openrouter.ai
 All Models: https://openrouter.ai/models
 Get your API Key here: https://openrouter.ai/settings/keys
+Provider Routing Docs: https://openrouter.ai/docs/features/provider-routing
 """
 
 import os
-from typing import Any
+from typing import Any, List, Dict
 
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from inspect_ai.model import GenerateConfig
@@ -33,10 +45,49 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         base_url: str | None = None,
         api_key: str | None = None,
         config: GenerateConfig = GenerateConfig(),
+        only: List[str] | str | None = None,
+        order: List[str] | str | None = None,
+        allow_fallbacks: bool | None = None,
+        ignore: List[str] | str | None = None,
+        sort: str | None = None,
+        max_price: Dict[str, float] | None = None,
+        quantizations: List[str] | str | None = None,
+        require_parameters: bool | None = None,
+        data_collection: str | None = None,
         **model_args: Any,
     ) -> None:
         # Remove provider prefix
         model_name_clean = model_name.replace("openrouter/", "", 1)
+
+        # Build provider routing object from parameters
+        provider_params: Dict[str, Any] = {}
+
+        # Handle list/string parameters that can be passed as comma-separated strings
+        def _parse_list_param(param: List[str] | str | None) -> List[str] | None:
+            if param is None:
+                return None
+            if isinstance(param, str):
+                return [p.strip() for p in param.split(",")]
+            return param
+
+        if only is not None:
+            provider_params["only"] = _parse_list_param(only)
+        if order is not None:
+            provider_params["order"] = _parse_list_param(order)
+        if ignore is not None:
+            provider_params["ignore"] = _parse_list_param(ignore)
+        if quantizations is not None:
+            provider_params["quantizations"] = _parse_list_param(quantizations)
+        if allow_fallbacks is not None:
+            provider_params["allow_fallbacks"] = allow_fallbacks
+        if sort is not None:
+            provider_params["sort"] = sort
+        if max_price is not None:
+            provider_params["max_price"] = max_price
+        if require_parameters is not None:
+            provider_params["require_parameters"] = require_parameters
+        if data_collection is not None:
+            provider_params["data_collection"] = data_collection
 
         base_url = base_url or self.DEFAULT_BASE_URL
 
@@ -59,6 +110,11 @@ class OpenRouterAPI(OpenAICompatibleAPI):
             }
         )
 
+        # Store provider routing parameters for injection into requests
+        self._extra_body = {}
+        if provider_params:
+            self._extra_body["provider"] = provider_params
+
         super().__init__(
             model_name=model_name_clean,
             base_url=base_url,
@@ -68,6 +124,25 @@ class OpenRouterAPI(OpenAICompatibleAPI):
             service_base_url=self.DEFAULT_BASE_URL,
             **model_args,
         )
+
+        # Inject provider routing parameters into all chat completion requests.
+        # This is necessary because Inspect-ai doesn't properly pass config.extra_body through to the underlying client calls
+        if self._extra_body:
+            original_create = self.client.chat.completions.create
+
+            def create_with_provider_routing(**kwargs):
+                # Merge provider routing parameters with any existing extra_body
+                if "extra_body" not in kwargs:
+                    kwargs["extra_body"] = {}
+                if kwargs["extra_body"] is None:
+                    kwargs["extra_body"] = {}
+                kwargs["extra_body"].update(self._extra_body)
+                return original_create(**kwargs)
+
+            # Replace the create method
+            setattr(
+                self.client.chat.completions, "create", create_with_provider_routing
+            )
 
     def service_model_name(self) -> str:
         """Return model name without service prefix."""


### PR DESCRIPTION
## Summary

Adds support for the following Openrouter provider routing args: https://openrouter.ai/docs/features/provider-routing

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [x] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made
- Add support for new -M flags for Openrouter routing args
- Inject these arg flags into the Openrouter request

## Testing

<!-- Describe how you tested your changes -->
- [x] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [x] I have tested with multiple model providers (if applicable)
- [x] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues -->
Closes #

## Additional Context

Example showing the flag -M only=providername
<img width="348" height="206" alt="Screenshot 2025-09-21 at 3 25 52 PM" src="https://github.com/user-attachments/assets/c25005cf-2704-4e64-8cca-770d3f7f7d29" />


