### PR TITLE
chore(mcq-eval): accept more dataset types

### DIFF
--- a/docs/development/mcq.mdx
+++ b/docs/development/mcq.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCQ Eval"
+title: "Multiple Choice Evals (MCQ)"
 description: "Robust infrastructure to support integration multiple choice question (MCQ) benchmarks."
 ---
 
@@ -57,6 +57,7 @@ MCQEval accepts additional configuration parameters:
 def MCQEval(
     *,
     name: str,                                        # Task name
+    dataset_type: str = "hf"                          # "hf", "csv", or "json"
     dataset_path: str,                                # Hugging Face dataset path/name
     record_to_mcq_sample,                             # Function converting a raw record into an `MCQSample`
     split: str,                                       # HF dataset split (e.g., "train", "validation", "test")
@@ -70,7 +71,7 @@ def MCQEval(
     dataset_kwargs: Optional[dict[str, Any]] = None,  # Additional dataset-specific parameters
 ) -> Task
 ```
-When called, MCQEval loads the HuggingFace dataset according to the mapping function provided,
+When called, MCQEval loads the dataset type (default hf) according to the provided mapping function, e.g.,
 ```
 dataset = hf_dataset(
     dataset_path,


### PR DESCRIPTION
## Summary

Allow csv and json datasets in addition to hf.

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [X] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

- Adds dataset_type parameter to MCQEval (default = "hf")
- Calls appropriate InspectAI dataset loader
- MCQEval docs updated accordingly

## Testing

<!-- Describe how you tested your changes -->
- [X] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [ ] I have tested with multiple model providers (if applicable)
- [X] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `dataset_type` to `MCQEval` to load `hf`, `csv`, or `json` datasets; `split` is now optional except for `hf`, and docs updated accordingly.
> 
> - **Utils (`src/openbench/utils/mcq.py`)**:
>   - Extend `MCQEval` with `dataset_type` (default `"hf"`) to support `hf_dataset`, `csv_dataset`, and `json_dataset`.
>   - Make `split` optional; enforce it only when `dataset_type == "hf"`; raise on unsupported types.
>   - Import `csv_dataset` and `json_dataset` alongside `hf_dataset`.
> - **Docs (`docs/development/mcq.mdx`)**:
>   - Rename title and document `dataset_type` and loader behavior; note `split` requirement only for `hf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0968bd707b14ae21966dc69cf1f85bbeeec11990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->