### PR TITLE
Add LegalSupport benchmark for legal citation analysis

### DIFF
--- a/docs/snippets/benchmarks.data.mdx
+++ b/docs/snippets/benchmarks.data.mdx
@@ -544,6 +544,19 @@ export const benchmarksData = [
     "is_alpha": false
   },
   {
+    "name": "LegalSupport",
+    "description": "Legal citation support identification - identify which citation provides stronger support for a legal argument",
+    "category": "domain-specific",
+    "tags": [
+      "multiple-choice",
+      "legal",
+      "reasoning",
+      "citation-analysis"
+    ],
+    "function_name": "legalsupport",
+    "is_alpha": false
+  },
+  {
     "name": "LiveMCPBench",
     "description": "Benchmark for evaluating LLM agents on real-world tasks using the Model Context Protocol (MCP) - 95 tasks across different categories",
     "category": "core",

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -292,3 +292,6 @@ from .evals.matharena.brumo_2025.brumo_2025 import brumo_2025  # noqa: F401, E40
 from .evals.matharena.hmmt_feb_2023.hmmt_feb_2023 import hmmt_feb_2023  # noqa: F401, E402
 from .evals.matharena.hmmt_feb_2024.hmmt_feb_2024 import hmmt_feb_2024  # noqa: F401, E402
 from .evals.matharena.hmmt_feb_2025.hmmt_feb_2025 import hmmt_feb_2025  # noqa: F401, E402
+
+# Domain-Specific benchmarks
+from .evals.legalsupport import legalsupport  # noqa: F401, E402

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -1068,6 +1068,14 @@ BENCHMARKS = {
         function_name="livemcpbench",
         is_alpha=False,
     ),
+    "legalsupport": BenchmarkMetadata(
+        name="LegalSupport",
+        description="Legal citation support identification - identify which citation provides stronger support for a legal argument",
+        category="domain-specific",
+        tags=["multiple-choice", "legal", "reasoning", "citation-analysis"],
+        module_path="openbench.evals.legalsupport",
+        function_name="legalsupport",
+    ),
 }
 
 

--- a/src/openbench/evals/legalsupport.py
+++ b/src/openbench/evals/legalsupport.py
@@ -1,0 +1,85 @@
+"""
+LegalSupport: Legal Support Identification Benchmark
+
+This benchmark evaluates models on their ability to identify the most supporting legal citation
+given a context and two candidate citations. The task requires understanding legal language
+and reasoning about which citation provides stronger support for a legal argument.
+
+Dataset: lighteval/LegalSupport
+Split: test (3047 samples)
+
+Sample usage:
+```bash
+bench eval legalsupport --model groq/llama-3.1-70b-versatile
+```
+"""
+
+from inspect_ai import Task, task
+from inspect_ai.solver import Choices
+from inspect_ai.solver._multiple_choice import prompt
+from openbench.utils.mcq import MCQEval, MCQSample
+
+
+LEGALSUPPORT_TEMPLATE = r"""
+Answer the following multiple choice question. The entire content of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of {letters}.
+
+{question}
+
+{choices}
+""".strip()
+
+
+def record_to_mcq_sample(record: dict) -> MCQSample:
+    """Convert a LegalSupport record to an OpenBench MCQSample.
+
+    The dataset contains:
+    - context: Legal text where citations appear
+    - citation_a: First citation with signal, identifier, parenthetical, sentence
+    - citation_b: Second citation with signal, identifier, parenthetical, sentence
+    - label: Either 'a' or 'b' indicating which citation is more supportive
+    """
+    context = record["context"]
+
+    # Format citation A
+    citation_a = record["citation_a"]
+    citation_a_text = f"Citation A: {citation_a['identifier']}"
+    if citation_a.get("parenthetical"):
+        citation_a_text += f" ({citation_a['parenthetical']})"
+
+    # Format citation B
+    citation_b = record["citation_b"]
+    citation_b_text = f"Citation B: {citation_b['identifier']}"
+    if citation_b.get("parenthetical"):
+        citation_b_text += f" ({citation_b['parenthetical']})"
+
+    question = f"Given the following legal context, which citation provides stronger support?\n\nContext: {context}\n\nWhich citation is more supportive?"
+
+    # Create binary choice with both citations
+    input_msg = prompt(
+        question=question,
+        choices=Choices([citation_a_text, citation_b_text]),
+        template=str(LEGALSUPPORT_TEMPLATE),
+    )
+
+    # Convert 'a'/'b' label to 'A'/'B'
+    target = record["label"].upper()
+
+    return MCQSample(
+        input=input_msg,
+        target=target,
+        metadata={
+            "case_id": str(record.get("case_id", "")),
+        },
+    )
+
+
+@task
+def legalsupport(split: str = "test") -> Task:
+    """Evaluate the LegalSupport benchmark for legal citation support identification."""
+    return MCQEval(
+        name="legalsupport",
+        dataset_path="lighteval/LegalSupport",
+        record_to_mcq_sample=record_to_mcq_sample,
+        split=split,
+        auto_id=True,
+    )


### PR DESCRIPTION
## Summary
- Adds LegalSupport benchmark for legal citation support identification
- Evaluates ability to determine which legal citation provides stronger support
- 3,047 test samples requiring legal language understanding and reasoning

## Benchmark Details
- **Category**: Domain-Specific (Legal)
- **Format**: Binary multiple choice (Citation A vs Citation B)
- **Dataset**: lighteval/LegalSupport
- **Samples**: 3,047 legal contexts with paired citations
- **Task**: Identify which citation provides stronger support for legal argument
- **Metadata**: Includes case IDs for analysis

## Test plan
- [x] Pre-commit hooks pass
- [x] Registry import added
- [x] Config metadata added
- [x] File copied from lighteval port branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)