### PR TITLE
chore: alphabetize available benchmarks error

### DIFF
--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -4462,7 +4462,8 @@ def load_task(benchmark_name: str, allow_alpha: bool = False) -> Callable:
     # Neither registry nor valid path
     raise ValueError(
         f"Unknown benchmark: '{benchmark_name}'. "
-        f"Available benchmarks: {', '.join(TASK_REGISTRY.keys())}"
+        # return available benchmarks alphabetically
+        f"Available benchmarks: {', '.join(sorted(TASK_REGISTRY.keys()))}"
     )
 
 


### PR DESCRIPTION
## Summary

When user attempts to run `bench eval` with an unregistered task, an error is returned, along with a list of available benchmarks. This PR alphabetizes the available benchmarks list output.

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [X] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Alphabetizes the "Available benchmarks" list in the unknown benchmark error output.
> 
> - **CLI**:
>   - In `load_task` (`src/openbench/config.py`), the "Available benchmarks" list is now sorted (`sorted(TASK_REGISTRY.keys())`) in the error message for unknown benchmarks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc22ad513d9854c06cda04dca52cfd364da291dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->