### PR TITLE
feat(plugins): add entry point system for external benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,32 @@ The following benchmarks use a grader model:
 
 ## Building Your Own Evals
 
-openbench is built on [Inspect AI](https://inspect.aisi.org.uk/). To create custom evaluations, check out their excellent [documentation](https://inspect.aisi.org.uk/). Once you do build your own private evaluations with Inspect AI that you don't want to open-source, you can point openbench at them with `bench eval <path>` to run!
+openbench is built on [Inspect AI](https://inspect.aisi.org.uk/). To create custom evaluations, check out their excellent [documentation](https://inspect.aisi.org.uk/).
+
+### Quick Eval: Run from Path
+
+For one-off or private evaluations, point openbench directly at your eval:
+
+```bash
+bench eval /path/to/my_eval.py --model groq/llama-3.3-70b-versatile
+```
+
+### Plugin System: Distribute as Packages
+
+openbench supports a **plugin system via Python entry points**. Package your benchmarks and distribute them independently:
+
+```toml
+# pyproject.toml
+[project.entry-points."openbench.benchmarks"]
+my_benchmark = "my_pkg.metadata:get_benchmark_metadata"
+```
+
+After `pip install my-benchmark-package`, your benchmark appears in `bench list` and works with all CLI commands. Perfect for:
+- Sharing benchmarks across teams
+- Versioning evaluations independently
+- Overriding built-in benchmarks with custom implementations
+
+📖 **Full guide**: [Extending openbench](https://openbench.groq.com/development/extending)
 
 ## Exporting Logs to Hugging Face
 

--- a/docs/development/architecture.mdx
+++ b/docs/development/architecture.mdx
@@ -351,12 +351,37 @@ openbench/
 
 ## Extension Points - Adding New Benchmarks
 
+### Built-in Benchmarks (Contribution)
+
+To add a benchmark to openbench core:
+
 1. Eval task in `evals/`
 2. Dataset loader in `datasets/`
 3. Scoring logic in `scorers/`
-3. Custom solver in `solvers/`
-4. Custom metric in `metrics/`
-5. Benchmark metadata in `config.py`
-6. Import eval task into `_registry.py`
+4. Custom solver in `solvers/` (if needed)
+5. Custom metric in `metrics/` (if needed)
+6. Benchmark metadata in `config.py`
+7. Import eval task into `_registry.py`
 
 <Tip> openbench provides infrastructure for multiple-choice question (MCQ) evals. [See more](mcq).</Tip>
+
+### External Benchmarks (Plugin System)
+
+openbench supports a **plugin system via Python entry points**, allowing you to distribute custom benchmarks as standalone packages:
+
+```toml pyproject.toml
+[project.entry-points."openbench.benchmarks"]
+my_benchmark = "my_pkg.metadata:get_benchmark_metadata"
+```
+
+After installing your package, benchmarks appear in `bench list` and work with all CLI commands.
+
+**Benefits:**
+- No need to modify openbench source code
+- Version and distribute benchmarks independently
+- Share benchmarks across teams/organizations
+- Override built-in benchmarks with custom implementations
+
+<Tip>
+See the [Extending openbench](extending) guide for comprehensive documentation, examples, and best practices.
+</Tip>

--- a/docs/development/extending.mdx
+++ b/docs/development/extending.mdx
@@ -1,0 +1,280 @@
+---
+title: "Extending openbench"
+description: "Create and distribute custom benchmarks as Python packages"
+---
+
+## Overview
+
+openbench supports a plugin system via Python entry points, allowing you to:
+
+- **Distribute custom benchmarks** as standalone Python packages
+- **Override built-in benchmarks** with patched or enhanced versions
+- **Share benchmarks** across teams without modifying openbench source
+- **Version control benchmark implementations** independently
+
+External packages register benchmarks through `pyproject.toml` entry points. Once installed, they appear in `bench list` and work seamlessly with all CLI commands.
+
+## Quick Start
+
+### 1. Create Your Package Structure
+
+```bash
+my-benchmark-package/
+├── src/
+│   └── my_benchmarks/
+│       ├── __init__.py
+│       ├── metadata.py      # BenchmarkMetadata definitions
+│       └── my_eval.py        # Task implementation
+├── pyproject.toml
+└── README.md
+```
+
+### 2. Define Your Benchmark
+
+```python src/my_benchmarks/my_eval.py
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, MemoryDataset
+from inspect_ai.scorer import match
+from inspect_ai.solver import generate
+
+@task
+def my_custom_benchmark():
+    """My custom evaluation task."""
+    # Define your dataset
+    samples = [
+        Sample(
+            input="What is 2+2?",
+            target="4",
+        ),
+        # ... more samples
+    ]
+
+    return Task(
+        dataset=MemoryDataset(samples=samples, name="my_custom_benchmark"),
+        solver=[generate()],
+        scorer=match(),
+        name="my_custom_benchmark",
+    )
+```
+
+### 3. Create Benchmark Metadata
+
+```python src/my_benchmarks/metadata.py
+from openbench.utils import BenchmarkMetadata
+
+def get_benchmark_metadata():
+    """Return benchmark metadata for entry point registration."""
+    return BenchmarkMetadata(
+        name="My Custom Benchmark",
+        description="A custom benchmark for evaluating X",
+        category="community",
+        tags=["custom", "math", "reasoning"],
+        module_path="my_benchmarks.my_eval",
+        function_name="my_custom_benchmark",
+        is_alpha=False,
+    )
+```
+
+### 4. Register Entry Point
+
+```toml pyproject.toml
+[project]
+name = "my-benchmark-package"
+version = "0.1.0"
+dependencies = [
+    "openbench>=0.4.1",
+]
+
+[project.entry-points."openbench.benchmarks"]
+my_custom_benchmark = "my_benchmarks.metadata:get_benchmark_metadata"
+```
+
+### 5. Install and Use
+
+```bash
+# Install your package
+pip install my-benchmark-package
+
+# Your benchmark now appears in openbench
+bench list
+bench describe my_custom_benchmark
+bench eval my_custom_benchmark --model groq/llama-3.1-70b
+```
+
+## Entry Point Specifications
+
+### Single Benchmark Registration
+
+Register one benchmark with the entry point name:
+
+```toml pyproject.toml
+[project.entry-points."openbench.benchmarks"]
+my_benchmark = "my_pkg.metadata:get_single_benchmark"
+```
+
+```python my_pkg/metadata.py
+from openbench.utils import BenchmarkMetadata
+
+def get_single_benchmark() -> BenchmarkMetadata:
+    """Entry point function that returns benchmark metadata."""
+    return BenchmarkMetadata(
+        name="My Benchmark",
+        description="...",
+        category="community",
+        tags=["custom"],
+        module_path="my_pkg.eval",
+        function_name="my_benchmark",
+    )
+```
+
+<Note>
+Entry points should reference a **callable function** that returns `BenchmarkMetadata` or `dict[str, BenchmarkMetadata]`.
+The function will be called automatically when loading entry points.
+</Note>
+
+### Multiple Benchmarks Registration
+
+Register multiple benchmarks from one entry point:
+
+```toml pyproject.toml
+[project.entry-points."openbench.benchmarks"]
+my_suite = "my_pkg.metadata:get_benchmark_suite"
+```
+
+```python my_pkg/metadata.py
+from openbench.utils import BenchmarkMetadata
+
+def get_benchmark_suite() -> dict[str, BenchmarkMetadata]:
+    """Return multiple benchmarks."""
+    return {
+        "benchmark_a": BenchmarkMetadata(
+            name="Benchmark A",
+            description="First benchmark in suite",
+            category="community",
+            tags=["suite", "part-a"],
+            module_path="my_pkg.benchmark_a",
+            function_name="benchmark_a",
+        ),
+        "benchmark_b": BenchmarkMetadata(
+            name="Benchmark B",
+            description="Second benchmark in suite",
+            category="community",
+            tags=["suite", "part-b"],
+            module_path="my_pkg.benchmark_b",
+            function_name="benchmark_b",
+        ),
+    }
+```
+
+## BenchmarkMetadata Fields
+
+<ParamField path="name" type="string" required>
+  Human-readable display name shown in `bench list` and `bench describe`
+</ParamField>
+
+<ParamField path="description" type="string" required>
+  Detailed description of what the benchmark evaluates
+</ParamField>
+
+<ParamField path="category" type="string" required>
+  Category for grouping. Common values: `"core"`, `"community"`, `"math"`, `"cybersecurity"`
+</ParamField>
+
+<ParamField path="tags" type="List[str]" required>
+  Tags for searchability (e.g., `["multiple-choice", "reasoning", "knowledge"]`)
+</ParamField>
+
+<ParamField path="module_path" type="string" required>
+  Python import path to the module containing the task function (e.g., `"my_pkg.evals.mmlu"`)
+</ParamField>
+
+<ParamField path="function_name" type="string" required>
+  Name of the `@task` decorated function to load (e.g., `"mmlu"`)
+</ParamField>
+
+<ParamField path="is_alpha" type="bool" default={false}>
+  Mark as experimental/alpha. Requires `--alpha` flag to run.
+</ParamField>
+
+## Overriding Built-in Benchmarks
+
+Entry points are merged **after** built-in benchmarks, allowing you to override them.
+This is useful for:
+
+- **Fixing dataset bugs** discovered in production
+- **Adding custom splits** or subsets
+- **Swapping scoring implementations** (e.g., using a different grader model)
+- **Patching behavior** without waiting for upstream fixes
+
+<Warning>
+Overriding built-ins can break reproducibility. Pin your dependencies and document
+any overrides clearly.
+</Warning>
+
+### Example: Override MMLU with Custom Version
+
+```toml pyproject.toml
+[project.entry-points."openbench.benchmarks"]
+mmlu = "my_pkg.custom_mmlu:get_metadata"
+```
+
+```python my_pkg/custom_mmlu.py
+from openbench.utils import BenchmarkMetadata
+from inspect_ai import Task, task
+from inspect_ai.dataset import csv_dataset
+
+@task
+def custom_mmlu():
+    """MMLU with fixed dataset URL."""
+    return Task(
+        dataset=csv_dataset("https://my-server.com/fixed-mmlu.csv"),
+        # ... rest of implementation
+        name="mmlu",
+    )
+
+def get_metadata() -> BenchmarkMetadata:
+    return BenchmarkMetadata(
+        name="MMLU (Fixed)",
+        description="MMLU with corrected dataset",
+        category="core",
+        tags=["multiple-choice", "knowledge", "patched"],
+        module_path="my_pkg.custom_mmlu",
+        function_name="custom_mmlu",
+    )
+```
+
+After installing this package, `bench eval mmlu` will use your custom version.
+
+## Troubleshooting
+
+### Benchmark Not Appearing
+
+If your benchmark doesn't show up in `bench list`:
+
+1. **Verify installation**: `pip list | grep my-benchmark-package`
+2. **Check entry point registration**:
+   ```bash
+   python -c "from importlib.metadata import entry_points; print([ep for ep in entry_points()['openbench.benchmarks']])"
+   ```
+3. **Check for errors**: Look for warnings in CLI output
+4. **Verify metadata function**: Ensure it returns `BenchmarkMetadata` or `dict[str, BenchmarkMetadata]`
+
+### Import Errors
+
+If you see `ModuleNotFoundError`:
+
+- Ensure `module_path` in `BenchmarkMetadata` is correct
+- Check that your package is properly installed
+- Verify the task function exists and is decorated with `@task`
+
+### Override Not Working
+
+If your override isn't taking effect:
+
+- Entry points are loaded at package import time
+- Restart your Python session / reinstall the package
+- Check that the entry point name exactly matches the built-in name
+
+<Tip>
+For questions or help, open an issue on [GitHub](https://github.com/groq/openbench/issues).
+</Tip>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,6 +43,7 @@
         "group": "Development",
         "pages": [
           "development/architecture",
+          "development/extending",
           "development/contributing",
           "development/mcq"
         ]

--- a/src/openbench/_cli/utils.py
+++ b/src/openbench/_cli/utils.py
@@ -5,7 +5,7 @@ Utility functions shared across CLI commands.
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 import yaml
-from openbench.config import BenchmarkMetadata
+from openbench.utils import BenchmarkMetadata
 
 
 def get_category_display_name(category: str) -> str:

--- a/src/openbench/utils/__init__.py
+++ b/src/openbench/utils/__init__.py
@@ -1,1 +1,5 @@
 """Core utilities for benchmarking."""
+
+from .metadata import BenchmarkMetadata
+
+__all__ = ["BenchmarkMetadata"]

--- a/src/openbench/utils/metadata.py
+++ b/src/openbench/utils/metadata.py
@@ -1,0 +1,23 @@
+"""
+Metadata utilities for openbench benchmarks.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class BenchmarkMetadata:
+    """Minimal metadata for a benchmark - only what can't be extracted."""
+
+    name: str  # Human-readable display name
+    description: str  # Human-written description
+    category: str  # Category for grouping
+    tags: List[str]  # Tags for searchability
+
+    # Registry info - still needed
+    module_path: str
+    function_name: str
+
+    # Alpha/experimental flag
+    is_alpha: bool = False  # Whether this benchmark is experimental/alpha

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,13 @@
 """Test the registry module functionality."""
 
 import pytest
-from openbench.config import load_task, TASK_REGISTRY
+from unittest.mock import Mock, patch
+from openbench.config import (
+    load_task,
+    TASK_REGISTRY,
+    _load_entry_point_benchmarks,
+)
+from openbench.utils import BenchmarkMetadata
 
 
 def test_task_registry_contents():
@@ -57,3 +63,244 @@ def test_load_task_alpha_requires_flag_with_dash_variant():
 
     task = load_task("graphwalks-parents", allow_alpha=True)
     assert callable(task)
+
+
+# Entry Point Tests
+
+
+@patch("openbench.config.entry_points")
+def test_load_entry_point_single_benchmark(mock_entry_points):
+    """Test loading a single benchmark from an entry point."""
+    # Create metadata that will be returned
+    metadata = BenchmarkMetadata(
+        name="Custom Benchmark",
+        description="A custom benchmark from an external package",
+        category="community",
+        tags=["custom"],
+        module_path="custom_pkg.benchmark",
+        function_name="custom_benchmark",
+    )
+
+    # Create a mock function that returns the metadata
+    mock_func = Mock(return_value=metadata)
+
+    # Create a mock entry point
+    mock_ep = Mock()
+    mock_ep.name = "custom_benchmark"
+    mock_ep.load.return_value = mock_func
+
+    # Mock entry_points().select() to return our mock
+    mock_select = Mock(return_value=[mock_ep])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify the benchmark was loaded
+    assert "custom_benchmark" in result
+    assert result["custom_benchmark"].name == "Custom Benchmark"
+    assert result["custom_benchmark"].category == "community"
+    # Verify the function was called
+    mock_func.assert_called_once()
+
+
+@patch("openbench.config.entry_points")
+def test_load_entry_point_multiple_benchmarks(mock_entry_points):
+    """Test loading multiple benchmarks from a single entry point."""
+    # Create the dict that will be returned
+    benchmarks_dict = {
+        "benchmark_a": BenchmarkMetadata(
+            name="Benchmark A",
+            description="First benchmark",
+            category="community",
+            tags=["custom"],
+            module_path="custom_pkg.benchmark_a",
+            function_name="benchmark_a",
+        ),
+        "benchmark_b": BenchmarkMetadata(
+            name="Benchmark B",
+            description="Second benchmark",
+            category="community",
+            tags=["custom"],
+            module_path="custom_pkg.benchmark_b",
+            function_name="benchmark_b",
+        ),
+    }
+
+    # Create a mock function that returns the dict
+    mock_func = Mock(return_value=benchmarks_dict)
+
+    # Create a mock entry point
+    mock_ep = Mock()
+    mock_ep.name = "custom_pkg_benchmarks"
+    mock_ep.load.return_value = mock_func
+
+    # Mock entry_points to return our mock
+    mock_select = Mock(return_value=[mock_ep])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify both benchmarks were loaded
+    assert "benchmark_a" in result
+    assert "benchmark_b" in result
+    assert result["benchmark_a"].name == "Benchmark A"
+    assert result["benchmark_b"].name == "Benchmark B"
+    # Verify the function was called
+    mock_func.assert_called_once()
+
+
+@patch("openbench.config.entry_points")
+@patch("openbench.config.logger")
+def test_load_entry_point_error_handling(mock_logger, mock_entry_points):
+    """Test that entry point loading errors are handled gracefully."""
+    # Create a mock entry point that raises an error
+    mock_ep_error = Mock()
+    mock_ep_error.name = "broken_benchmark"
+    mock_ep_error.load.side_effect = ImportError("Module not found")
+
+    # Create a valid entry point
+    mock_ep_valid = Mock()
+    mock_ep_valid.name = "valid_benchmark"
+    mock_ep_valid.load.return_value = BenchmarkMetadata(
+        name="Valid Benchmark",
+        description="A valid benchmark",
+        category="community",
+        tags=["custom"],
+        module_path="valid_pkg.benchmark",
+        function_name="valid_benchmark",
+    )
+
+    # Mock entry_points().select() to return both
+    mock_select = Mock(return_value=[mock_ep_error, mock_ep_valid])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify valid benchmark was loaded, broken one was skipped
+    assert "valid_benchmark" in result
+    assert "broken_benchmark" not in result
+
+    # Check warning was logged
+    mock_logger.warning.assert_called()
+    warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("Failed to load benchmark from entry point 'broken_benchmark'" in call for call in warning_calls)
+
+
+@patch("openbench.config.entry_points")
+@patch("openbench.config.logger")
+def test_load_entry_point_invalid_return_type(mock_logger, mock_entry_points):
+    """Test handling of entry points that return invalid types."""
+    # Create a mock entry point that returns invalid type
+    mock_ep = Mock()
+    mock_ep.name = "invalid_benchmark"
+    mock_ep.load.return_value = "not a BenchmarkMetadata"
+
+    # Mock entry_points().select() to return our mock
+    mock_select = Mock(return_value=[mock_ep])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify nothing was loaded
+    assert len(result) == 0
+
+    # Check warning was logged
+    mock_logger.warning.assert_called()
+    warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("returned unexpected type" in call for call in warning_calls)
+
+
+@patch("openbench.config.entry_points")
+def test_load_entry_point_can_override_builtin(mock_entry_points):
+    """Test that entry points can override built-in benchmarks."""
+    # Create metadata for override
+    metadata = BenchmarkMetadata(
+        name="Custom MMLU",
+        description="A custom version of MMLU",
+        category="custom",
+        tags=["custom"],
+        module_path="custom_pkg.mmlu",
+        function_name="custom_mmlu",
+    )
+
+    # Create a mock function that returns the metadata
+    mock_func = Mock(return_value=metadata)
+
+    # Create a mock entry point that overrides a built-in
+    mock_ep = Mock()
+    mock_ep.name = "mmlu"  # This is a built-in benchmark
+    mock_ep.load.return_value = mock_func
+
+    # Mock entry_points().select() to return our mock
+    mock_select = Mock(return_value=[mock_ep])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify the entry point was loaded (can override)
+    assert "mmlu" in result
+    assert result["mmlu"].name == "Custom MMLU"
+    assert result["mmlu"].category == "custom"
+    mock_func.assert_called_once()
+
+
+@patch("openbench.config.entry_points")
+def test_load_entry_point_override_in_dict(mock_entry_points):
+    """Test that dict entries can override built-in benchmarks."""
+    # Create the dict with both custom and override
+    benchmarks_dict = {
+        "custom_bench": BenchmarkMetadata(
+            name="Custom Benchmark",
+            description="A custom benchmark",
+            category="custom",
+            tags=["custom"],
+            module_path="custom_pkg.custom",
+            function_name="custom_bench",
+        ),
+        "mmlu": BenchmarkMetadata(  # This should override
+            name="Custom MMLU",
+            description="A custom version of MMLU",
+            category="custom",
+            tags=["custom"],
+            module_path="custom_pkg.mmlu",
+            function_name="custom_mmlu",
+        ),
+    }
+
+    # Create a mock function that returns the dict
+    mock_func = Mock(return_value=benchmarks_dict)
+
+    # Create a mock entry point
+    mock_ep = Mock()
+    mock_ep.name = "custom_benchmarks"
+    mock_ep.load.return_value = mock_func
+
+    # Mock entry_points().select() to return our mock
+    mock_select = Mock(return_value=[mock_ep])
+    mock_eps = Mock()
+    mock_eps.select = mock_select
+    mock_entry_points.return_value = mock_eps
+
+    # Load entry points
+    result = _load_entry_point_benchmarks()
+
+    # Verify both were loaded
+    assert "custom_bench" in result
+    assert "mmlu" in result
+    assert result["mmlu"].name == "Custom MMLU"
+    mock_func.assert_called_once()


### PR DESCRIPTION
Add openbench.benchmarks entry point group. External packages can now register benchmarks via pyproject.toml. Entry points override built-ins (merged last). Auto-calls callable entry points.

Tests: 13 unit tests, end-to-end verified
Docs: new extending.mdx guide, updated README and architecture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Python entry point plugins to register/override benchmarks, with supporting utils refactor, tests, and docs.
> 
> - **Core/Registry**:
>   - Add entry-point loading in `openbench.config` via `importlib.metadata.entry_points`, merging discovered benchmarks after built-ins to allow overrides (`_load_entry_point_benchmarks`, `BENCHMARKS` merge).
>   - Normalize key lookup unchanged; registry generation continues from merged `BENCHMARKS`.
> - **Utils**:
>   - Extract `BenchmarkMetadata` to `openbench.utils.metadata` and export in `openbench.utils.__init__`.
> - **CLI**:
>   - Update imports to use `openbench.utils.BenchmarkMetadata` in `_cli/utils.py`.
> - **Tests**:
>   - Add unit tests for entry-point loading, multiple/single returns, error handling, and overriding built-ins in `tests/test_registry.py`.
> - **Docs**:
>   - README: add quick path-based eval usage and new plugin system section with entry point example.
>   - `architecture.mdx`: document built-in vs external benchmarks and plugin benefits; add pointers to MCQ infra and extending guide.
>   - New guide `development/extending.mdx`; add to `docs/docs.json` navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fedb61a92ba9ccc33c4b6d50ea94a492538eb8b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->