### PR TITLE
fix: normalize benchmark keys during entry point merge

### DIFF
--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -4301,20 +4301,59 @@ _BUILTIN_BENCHMARKS = {
 }
 
 
-# Merge built-in benchmarks with those from entry points.
-# Entry points are merged last so they can override built-ins. This allows external
-# packages to patch/extend benchmarks (e.g., fixing dataset bugs, adding custom splits,
-# or swapping implementations). If you want stable behavior, pin your dependencies.
-BENCHMARKS = {
-    **_BUILTIN_BENCHMARKS,
-    **_load_entry_point_benchmarks(),
-}
-
-
 def _normalize_benchmark_key(name: str) -> str:
     """Normalize benchmark keys so '-' and '_' are treated the same."""
 
     return name.replace("-", "_")
+
+
+def _merge_benchmarks_with_normalization(
+    builtin: dict[str, BenchmarkMetadata],
+    entry_points: dict[str, BenchmarkMetadata],
+) -> dict[str, BenchmarkMetadata]:
+    """Merge benchmark dicts, treating '-' and '_' as equivalent for overrides.
+
+    Entry point benchmarks can override built-ins even if they differ only in
+    '-' vs '_'. The entry point's key format wins.
+
+    Args:
+        builtin: Built-in benchmark metadata
+        entry_points: Entry point benchmark metadata
+
+    Returns:
+        Merged benchmark dict with entry point overrides applied
+    """
+    merged = dict(builtin)
+
+    # Build a reverse lookup: normalized_key -> original_key (from built-ins)
+    builtin_normalized = {_normalize_benchmark_key(k): k for k in builtin.keys()}
+
+    for ep_key, ep_meta in entry_points.items():
+        normalized = _normalize_benchmark_key(ep_key)
+
+        # If an entry point overrides a built-in (even with different - vs _),
+        # remove the old key and add the new one
+        if normalized in builtin_normalized:
+            old_key = builtin_normalized[normalized]
+            if old_key != ep_key and old_key in merged:
+                del merged[old_key]
+                builtin_normalized[normalized] = ep_key
+
+        merged[ep_key] = ep_meta
+
+    return merged
+
+
+# Merge built-in benchmarks with those from entry points.
+# Entry points are merged last so they can override built-ins. This allows external
+# packages to patch/extend benchmarks (e.g., fixing dataset bugs, adding custom splits,
+# or swapping implementations). If you want stable behavior, pin your dependencies.
+# Keys differing only in '-' vs '_' are treated as referring to the same benchmark,
+# with the entry point's key format taking precedence.
+BENCHMARKS = _merge_benchmarks_with_normalization(
+    _BUILTIN_BENCHMARKS,
+    _load_entry_point_benchmarks(),
+)
 
 
 def _build_normalized_lookup(names: Iterable[str]) -> dict[str, str]:


### PR DESCRIPTION
## Problem

When entry points export benchmarks with keys like `mmlu_pro` and openbench has built-ins like `mmlu-pro`, the dictionary merge (`{**_BUILTIN_BENCHMARKS, **_load_entry_point_benchmarks()}`) creates **both** keys in the final `BENCHMARKS` dict since they're different strings. This defeats the intended override mechanism and causes a normalization conflict error:

```
ValueError: Benchmark names cannot differ only by '-' vs '_' (conflict between 'mmlu-pro' and 'mmlu_pro')
```

The documentation states "Entry points override built-ins" but this only works when the keys are **exactly identical**. Since openbench already normalizes `-` and `_` elsewhere (via `_normalize_benchmark_key`), this behavior is inconsistent.

## Solution

Introduce `_merge_benchmarks_with_normalization()` that:
1. Treats `-` and `_` as equivalent during the merge
2. When an entry point provides a benchmark that normalizes to the same key as a built-in, removes the old built-in key and adds the entry point's key
3. Ensures the entry point's key format wins

## Example

**Before:** If openbench has `mmlu-pro` and groq-bench exports `mmlu_pro`:
- Final dict: `{'mmlu-pro': <openbench>, 'mmlu_pro': <groq-bench>}` ❌ Conflict!

**After:** 
- Final dict: `{'mmlu_pro': <groq-bench>}` ✅ Override works correctly

## Testing

Tested with groq-bench which exports `mmlu_pro` to override openbench's `mmlu-pro`. After this fix:
- No normalization conflict error
- Entry point override works as documented
- groq-bench's implementation is used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Merge built-in and entry-point benchmarks with '-'/'_' key normalization so entry points override built-ins and their key format prevails.
> 
> - **Config**:
>   - Add `_merge_benchmarks_with_normalization(...)` to merge benchmarks treating `-`/`_` as equivalent; ensures entry-point overrides (last-wins) and preserves entry-point key format.
>   - Replace direct dict merge with normalized merge for `BENCHMARKS`; update comments accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8bdfd46d533ef0e4064831d1f52b8e4ea805d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->