### PR TITLE
fix: make core package actually install

### DIFF
--- a/packages/openbench-core/pyproject.toml
+++ b/packages/openbench-core/pyproject.toml
@@ -7,7 +7,6 @@ name = "openbench"
 version = "0.4.1"
 requires-python = ">=3.10"
 description = "openbench - open source, replicable, and standardized evaluation infrastructure"
-readme = "../../README.md"
 license = {text = "MIT"}
 authors = [
     { name="Aarush Sah" },

--- a/scripts/sync_pyproject.py
+++ b/scripts/sync_pyproject.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import os
 import re
+import os
 from pathlib import Path
 from typing import Callable
 
@@ -35,10 +35,6 @@ def adjust_relative_paths(content: str) -> str:
     """Update known relative paths so they remain valid from packages/openbench-core/."""
     replacements: tuple[Replacement, ...] = (
         (
-            re.compile(r'(readme\s*=\s*)"README\.md"'),
-            lambda m: f'{m.group(1)}"{_join_root("README.md")}"',
-        ),
-        (
             re.compile(r'(package-dir\s*=\s*\{""\s*=\s*)"src"'),
             lambda m: f'{m.group(1)}"{_join_root("src")}"',
         ),
@@ -66,6 +62,8 @@ def adjust_relative_paths(content: str) -> str:
     adjusted = content
     for pattern, replacement in replacements:
         adjusted, _ = pattern.subn(replacement, adjusted)
+
+    adjusted = re.sub(r'^\s*readme\s*=\s*".*?"\s*\n', "", adjusted, flags=re.MULTILINE)
 
     if ROOT_FROM_TARGET not in ("", "."):
         adjusted = re.sub(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the readme from the openbench-core pyproject and updates the sync script to strip it and adjust relative paths.
> 
> - **Core packaging**:
>   - Remove `readme` from `packages/openbench-core/pyproject.toml`.
> - **Sync script (`scripts/sync_pyproject.py`)**:
>   - Strip `readme` line during sync and retain relative path adjustments.
>   - Minor cleanup (import order).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c6448861bca4ef3d3a6b2d440dcd7b5d48c0be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->