### PR TITLE
feat(cli): add --system-prompt argument for controlling model behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ local-prompts.md
 .env
 build/
 **/build/
+**/data/

--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -487,6 +487,14 @@ def run_eval(
             envvar="BENCH_CODE_AGENT",
         ),
     ] = None,
+    system_prompt: Annotated[
+        Optional[str],
+        typer.Option(
+            "--system-prompt",
+            help="System prompt to use for all model requests. Useful for controlling thinking mode for vLLM models.",
+            envvar="BENCH_SYSTEM_PROMPT",
+        ),
+    ] = None,
 ) -> List[EvalLog] | None:
     """
     Run a benchmark on a model.
@@ -601,6 +609,7 @@ def run_eval(
                 reasoning_effort=reasoning_effort.value if reasoning_effort else None,
                 sandbox=sandbox,
                 log_format=log_format.value if log_format else None,
+                system_message=system_prompt,
             )
 
             typer.echo("Evaluation complete!")

--- a/tests/_cli/test_eval_command.py
+++ b/tests/_cli/test_eval_command.py
@@ -34,3 +34,15 @@ def test_invalid_reasoning_effort():
     """Test invalid reasoning effort parameter."""
     result = runner.invoke(app, ["eval", "mmlu", "--reasoning-effort", "invalid"])
     assert result.exit_code != 0
+
+
+def test_system_prompt_accepted():
+    """Test that system prompt parameter is accepted."""
+    # This test doesn't actually run the eval, but verifies the CLI accepts the parameter
+    # We expect it to fail on model/benchmark validation, not on the system-prompt parameter
+    result = runner.invoke(
+        app, ["eval", "mmlu", "--system-prompt", "Think step by step."]
+    )
+    # The command should fail on trying to run the actual eval, not on parsing the system-prompt
+    # So we check that the error is not about an unknown option
+    assert "--system-prompt" not in result.output or "no such option" not in result.output.lower()


### PR DESCRIPTION
## Summary
This PR adds a new `--system-prompt` CLI argument that allows users to specify a custom system prompt for model requests, as requested in https://github.com/groq/openbench/issues/233

## Changes
- Added `--system-prompt` parameter to `run_eval` command
- Parameter is passed through to Inspect AI's `system_message` configuration
- Added tests to verify the parameter is accepted correctly
- Updated `.gitignore` to exclude data directories

## Use Case
This is particularly useful for controlling thinking mode in vLLM models or other specialized model behaviors that require custom system prompts.

## Testing
- All pre-commit hooks pass (ruff, mypy)
- Tests updated to verify parameter acceptance
- Manually tested with local model setup