### PR TITLE
✨ feat: add BurnCloud as new AI model provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -195,6 +195,14 @@ def siliconflow() -> Type[ModelAPI]:
     return SiliconFlowAPI
 
 
+@modelapi(name="burncloud")
+def burncloud() -> Type[ModelAPI]:
+    """Register BurnCloud provider."""
+    from .model._providers.burncloud import BurnCloudAPI
+
+    return BurnCloudAPI
+
+
 def _override_builtin_groq_provider():
     """Replace Inspect AI's built-in groq provider with enhanced openbench version."""
     from inspect_ai._util.registry import _registry

--- a/src/openbench/model/_providers/burncloud.py
+++ b/src/openbench/model/_providers/burncloud.py
@@ -1,0 +1,50 @@
+"""BurnCloud provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+
+
+class BurnCloudAPI(OpenAICompatibleAPI):
+    """BurnCloud provider - OpenAI-compatible inference.
+
+    Uses OpenAI-compatible API with BurnCloud-specific configuration.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Extract model name without service prefix
+        model_name_clean = model_name.replace("burncloud/", "", 1)
+
+        # Set defaults for BurnCloud
+        base_url = base_url or os.environ.get(
+            "BURNCLOUD_BASE_URL", "https://ai.burncloud.com/v1"
+        )
+        api_key = api_key or os.environ.get("BURNCLOUD_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "BurnCloud API key not found. Set BURNCLOUD_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="burncloud",
+            service_base_url="https://ai.burncloud.com/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name


### PR DESCRIPTION
## 📝 Pull Request Description
This PR adds support for **BurnCloud API** as an alternative model provider, offering stable and cost-effective access to leading AI models.
### 🚀 What's Added
- BurnCloud API integration with OpenAI-compatible endpoints
- Support for multiple model families:
- Claude 4.0/3.7/3.5
- GPT 4o/4o-mini/o1/4.5 preview/o1-mini
- GPT-image-1
- Gemini 2.5 pro/2.0
- DeepSeek R1/V3
### 🔧 Implementation Details
- **Base URL**: `https://ai.burncloud.com/v1`
- **Compatibility**: Full OpenAI API format compatibility
- **Authentication**: Standard API key authentication
- **API Service**: [https://ai.burncloud.com](https://ai.burncloud.com)
 
- **Website**: [https://www.burncloud.com](https://www.burncloud.com)
### ✅ Testing
- [x] API connection tested
- [x] Model responses validated
- [x] Error handling implemented
- [x] Documentation updated
