### PR TITLE
feat(exercism): adding codex, claude, gemini and hidden tests flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ All cache data is stored under `~/.openbench`. The cache command helps you monit
 | `--hub-repo`         | `BENCH_HUB_REPO`          | `None`                    | Push results to a Hugging Face Hub dataset                       |
 | `--keep-livemcp-root` | `BENCH_KEEP_LIVEMCP_ROOT` | `False`                   | Allow preservation of root data after livemcpbench eval runs     |
 | `--code-agent`       | `BENCH_CODE_AGENT`        | `codex`                   | Select code agent for Exercism tasks (codex/aider/opencode/claude_code/roo) |
+| `--hidden-tests`     | `BENCH_HIDDEN_TESTS`      | `False`                   | Run Exercism agents with hidden tests |
 
 ## Grader Information
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ All cache data is stored under `~/.openbench`. The cache command helps you monit
 | `--log-format`       | `BENCH_LOG_FORMAT`        | `eval`                    | Output logging format (eval/json)                                |
 | `--hub-repo`         | `BENCH_HUB_REPO`          | `None`                    | Push results to a Hugging Face Hub dataset                       |
 | `--keep-livemcp-root` | `BENCH_KEEP_LIVEMCP_ROOT` | `False`                   | Allow preservation of root data after livemcpbench eval runs     |
-| `--code-agent`       | `BENCH_CODE_AGENT`        | `opencode`                | Select code agent for exercism tasks                             |
+| `--code-agent`       | `BENCH_CODE_AGENT`        | `codex`                   | Select code agent for Exercism tasks (codex/aider/opencode/claude_code/roo) |
 
 ## Grader Information
 

--- a/docs/evals/exercism.mdx
+++ b/docs/evals/exercism.mdx
@@ -54,6 +54,14 @@ Evaluate with a specific model:
 bench eval exercism --code-agent opencode --model groq/gpt-oss-120b
 ```
 
+Hide the Exercism test suites from the agent (tests still run after the edit loop):
+
+```bash
+bench eval exercism --hidden-tests
+```
+
+With `--hidden-tests`, the agent works inside a sanitized copy of the repo with the language-specific tests excluded, while the final verification still runs against the full workspace to ensure correctness.
+
 Run evaluation for a single language:
 
 ```bash
@@ -114,4 +122,3 @@ The multi-agent design allows for unique comparative analysis:
 - Compare how different models perform on identical tasks
 - Evaluate which code agent harness works best for different languages and models
 - Identify model strengths and weaknesses across programming paradigms
-

--- a/docs/evals/exercism.mdx
+++ b/docs/evals/exercism.mdx
@@ -21,8 +21,9 @@ The benchmark places agents in realistic development environments where they mus
 - **Multiple Code Agent Harnesses**: Evaluate models across different code agent frameworks on identical tasks for fair comparison:
   - **Aider** - AI-powered pair programming tool with git integration
   - **OpenCode** - OpenAI-compatible code generation tool
-  - **Claude** - Claude-based code editor with file system access
+  - **Claude Code** - Claude-based code editor with file system access
   - **Roo** - VS Code extension with interactive development
+  - **Codex** - OpenAI Codex cli coding agent
 
 - **Realistic Development Environment**: Agents work in full file system workspaces with multiple files, build configurations, and test suites
 
@@ -32,7 +33,7 @@ The benchmark places agents in realistic development environments where they mus
 
 ## Usage
 
-Run Exercism evaluation across all languages with the default code agent (opencode):
+Run Exercism evaluation across all languages with the default code agent (codex):
 
 ```bash
 bench eval exercism
@@ -41,6 +42,7 @@ bench eval exercism
 Specify a different code agent:
 
 ```bash
+bench eval exercism --code-agent codex
 bench eval exercism --code-agent aider
 bench eval exercism --code-agent claude
 bench eval exercism --code-agent roo

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -104,8 +104,8 @@ Harnesses
 
 Examples
 ```bash
-# Python with aider
-bench eval exercism_python --code-agent aider --model groq/llama-3.3-70b
+# Python with codex (default)
+bench eval exercism_python --code-agent codex --model openai/gpt-5
 
 # Go with Roo (requires OpenRouter model IDs)
 bench eval exercism_go --code-agent roo \
@@ -187,7 +187,7 @@ bench eval arabic_exams_general_knowledge --model groq/llama-3.3-70b
 
 Exercism (alpha)
 ```bash
-bench eval exercism_python --code-agent aider --model groq/llama-3.3-70b
+bench eval exercism_python --code-agent codex --model openai/gpt-5
 ```
 
 MultiChallenge

--- a/docs/snippets/benchmarks.data.mdx
+++ b/docs/snippets/benchmarks.data.mdx
@@ -8231,23 +8231,6 @@ export const evalGroupsData = [
     ]
   },
   {
-    "name": "Exercism",
-    "description": "Aggregate of 5 Exercism coding tasks",
-    "category": "eval-group",
-    "tags": [
-      "eval-group"
-    ],
-    "id": "exercism",
-    "benchmark_count": 5,
-    "benchmarks": [
-      "exercism_go",
-      "exercism_java",
-      "exercism_javascript",
-      "exercism_python",
-      "exercism_rust"
-    ]
-  },
-  {
     "name": "GLUE",
     "description": "Aggregate of 10 GLUE NLU tasks",
     "category": "eval-group",

--- a/packages/openbench-core/pyproject.toml
+++ b/packages/openbench-core/pyproject.toml
@@ -15,7 +15,9 @@ authors = [
 dependencies = [
     "datasets>=3.6.0",
     "groq>=0.33.0",
-    "inspect-ai==0.3.125",
+    "inspect-ai==0.3.141",
+    "inspect_swe>=0.2.26",
+    "anthropic>=0.69.0",
     "openai>=2.0.0",
     "pillow>=10.0.0",
     "jsonschema>=4.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ authors = [
 dependencies = [
     "datasets>=3.6.0",
     "groq>=0.33.0",
-    "inspect-ai==0.3.125",
+    "inspect-ai==0.3.141",
+    "inspect_swe>=0.2.26",
+    "anthropic>=0.69.0",
     "openai>=2.0.0",
     "pillow>=10.0.0",
     "jsonschema>=4.23.0",

--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -640,7 +640,7 @@ def run_eval(
         bool,
         typer.Option(
             "--alpha",
-            help="Allow running perimental/alpha benchmarks",
+            help="Allow running experimental/alpha benchmarks",
             envvar="BENCH_ALPHA",
         ),
     ] = False,
@@ -652,6 +652,14 @@ def run_eval(
             envvar="BENCH_CODE_AGENT",
         ),
     ] = None,
+    hidden_tests: Annotated[
+        bool,
+        typer.Option(
+            "--hidden-tests",
+            help="Run code agents in a sanitized copy of the repo with Exercism tests hidden",
+            envvar="BENCH_HIDDEN_TESTS",
+        ),
+    ] = False,
 ) -> List[EvalLog] | None:
     """
     Run a benchmark on a model.
@@ -704,6 +712,10 @@ def run_eval(
                 raise typer.BadParameter(
                     "For claude_code, --model must be an Anthropic model id prefixed with 'anthropic/'. "
                 )
+
+    # Propagate hidden test preference to tasks that support it
+    if hidden_tests:
+        task_args["hide_tests"] = True
 
     # Validate model names
     for model_name in model:

--- a/src/openbench/_cli/eval_command.py
+++ b/src/openbench/_cli/eval_command.py
@@ -640,7 +640,7 @@ def run_eval(
         bool,
         typer.Option(
             "--alpha",
-            help="Allow running experimental/alpha benchmarks",
+            help="Allow running perimental/alpha benchmarks",
             envvar="BENCH_ALPHA",
         ),
     ] = False,
@@ -696,6 +696,13 @@ def run_eval(
                 raise typer.BadParameter(
                     "For --code-agent roo, --model must be an OpenRouter model id prefixed with 'openrouter/'. "
                     "Example: --model openrouter/anthropic/claude-sonnet-4-20250514"
+                )
+    # claude code only supports anthropic models
+    if code_agent and code_agent.lower() == "claude_code":
+        for model_name in model:
+            if not model_name.startswith("anthropic/"):
+                raise typer.BadParameter(
+                    "For claude_code, --model must be an Anthropic model id prefixed with 'anthropic/'. "
                 )
 
     # Validate model names

--- a/src/openbench/agents/__init__.py
+++ b/src/openbench/agents/__init__.py
@@ -8,8 +8,9 @@ used in coding evaluations.
 from .base import BaseCodeAgent
 from .aider import AiderAgent
 from .opencode import OpenCodeAgent
-from .claude import ClaudeAgent
 from .roo import RooAgent
+from .claude import ClaudeCodeAgent
+from .codex import CodexAgent
 from .manager import AgentManager
 from .docker_manager import DockerManager
 
@@ -17,7 +18,8 @@ __all__ = [
     "BaseCodeAgent",
     "AiderAgent",
     "OpenCodeAgent",
-    "ClaudeAgent",
+    "ClaudeCodeAgent",
+    "CodexAgent",
     "RooAgent",
     "AgentManager",
     "DockerManager",

--- a/src/openbench/agents/__init__.py
+++ b/src/openbench/agents/__init__.py
@@ -8,6 +8,7 @@ used in coding evaluations.
 from .base import BaseCodeAgent
 from .aider import AiderAgent
 from .opencode import OpenCodeAgent
+from .gemini import GeminiAgent
 from .roo import RooAgent
 from .claude import ClaudeCodeAgent
 from .codex import CodexAgent
@@ -18,6 +19,7 @@ __all__ = [
     "BaseCodeAgent",
     "AiderAgent",
     "OpenCodeAgent",
+    "GeminiAgent",
     "ClaudeCodeAgent",
     "CodexAgent",
     "RooAgent",

--- a/src/openbench/agents/codex.py
+++ b/src/openbench/agents/codex.py
@@ -1,5 +1,5 @@
 """
-Claude Code agent backed by inspect_swe.
+Codex CLI agent backed by inspect_swe.
 """
 
 from __future__ import annotations
@@ -12,22 +12,21 @@ from inspect_ai.model import ChatMessageUser, ModelOutput
 from openbench.utils.cli_commands import format_execution_output
 
 from .base import BaseCodeAgent
-from inspect_swe import claude_code
+from inspect_swe import codex_cli
 
 
-class ClaudeCodeAgent(BaseCodeAgent):
-    """Claude Code CLI agent via inspect_swe."""
+class CodexAgent(BaseCodeAgent):
+    """Codex CLI agent via inspect_swe."""
 
     def __init__(self) -> None:
-        super().__init__("claude_code")
+        super().__init__("codex")
 
     async def execute(self, workdir: str, prompt_text: str, model: str) -> str:
-        """Execute Claude Code."""
-
+        """Execute Codex CLI agent."""
         try:
-            claude_agent = claude_code(cwd=workdir, model=model)
+            codex_agent = codex_cli(cwd=workdir, model=model)
             state = AgentState(messages=[ChatMessageUser(content=prompt_text)])
-            completed_state = await claude_agent(state)
+            completed_state = await codex_agent(state)
             stdout_text = _format_agent_output(completed_state.output)
             result = {
                 "returncode": 0,
@@ -37,25 +36,24 @@ class ClaudeCodeAgent(BaseCodeAgent):
             }
             return format_execution_output(result)
         except Exception as exc:  # pragma: no cover - defensive
-            return f"ERROR: claude_code execution failed: {exc}"
+            return f"ERROR: codex execution failed: {exc}"
 
     def resolve_model(self, state_model: str) -> str:
-        """Resolve the appropriate model string for Claude Code."""
         stripped = (state_model or "").strip()
         return stripped if stripped else self.get_default_model()
 
     def get_default_model(self) -> str:
-        return "anthropic/claude-sonnet-4-5-20250929"
+        return "openai/gpt-5"
 
     def get_description(self) -> str:
-        return "Claude Code agent."
+        return "Codex CLI agent"
 
     def get_dockerfile_commands(self) -> List[str]:
         return []
 
 
 def _format_agent_output(output: ModelOutput) -> str:
-    """Render agent output as plain text."""
+    """Render inspect_swe agent output as plain text."""
     if not output or not output.choices:
         return "Agent completed without emitting assistant output."
 

--- a/src/openbench/agents/codex.py
+++ b/src/openbench/agents/codex.py
@@ -24,7 +24,7 @@ class CodexAgent(BaseCodeAgent):
     async def execute(self, workdir: str, prompt_text: str, model: str) -> str:
         """Execute Codex CLI agent."""
         try:
-            codex_agent = codex_cli(cwd=workdir, model=model)
+            codex_agent = codex_cli(cwd=workdir, model=model, model_config=model)
             state = AgentState(messages=[ChatMessageUser(content=prompt_text)])
             completed_state = await codex_agent(state)
             stdout_text = _format_agent_output(completed_state.output)

--- a/src/openbench/agents/gemini.py
+++ b/src/openbench/agents/gemini.py
@@ -1,0 +1,130 @@
+"""
+Gemini CLI agent implementation.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from .base import BaseCodeAgent
+from openbench.utils.cli_commands import (
+    generate_env_setup_script,
+    write_prompt_to_file,
+    write_and_execute_script,
+    read_log_file,
+    format_execution_output,
+    get_gemini_script_template,
+)
+from openbench.utils.docker import GeminiCommands
+
+
+class GeminiAgent(BaseCodeAgent):
+    """Google Gemini CLI code generation tool."""
+
+    def __init__(self):
+        super().__init__("gemini")
+
+    async def execute(self, workdir: str, prompt_text: str, model: str) -> str:
+        """Execute Gemini CLI command.
+
+        Args:
+            workdir: Working directory path for the task
+            prompt_text: The prompt to send to gemini
+            model: Model string to use with gemini
+
+        Returns:
+            Formatted output string with gemini execution results
+        """
+        try:
+            if not await write_prompt_to_file(prompt_text, "gemini_prompt.txt"):
+                return "ERROR: failed to write prompt file"
+
+            # Get environment setup script
+            env_setup = generate_env_setup_script()
+
+            # Create gemini execution script
+            script_content = get_gemini_script_template().format(
+                workdir=workdir, env_setup=env_setup, model=model
+            )
+
+            # Execute the script
+            result = await write_and_execute_script(
+                script_content,
+                "gemini_script.sh",
+                timeout=1800,  # 30 minutes
+            )
+
+            additional_logs = []
+            gemini_log = await read_log_file(
+                "/tmp/gemini-output.log", "GEMINI", tail_lines=200
+            )
+            if gemini_log:
+                additional_logs.append(gemini_log)
+
+            return format_execution_output(result, additional_logs)
+
+        except Exception as e:
+            return f"ERROR: Failed to run gemini: {str(e)}"
+
+    def resolve_model(self, state_model: str) -> str:
+        """Resolve the appropriate model string for Gemini CLI.
+
+        Args:
+            state_model: Model from TaskState.model
+
+        Returns:
+            Resolved model string for Gemini CLI
+        """
+        if state_model.startswith("google/"):
+            return state_model[7:]
+
+        return state_model
+
+    def get_setup_commands(self) -> List[str]:
+        """Get setup commands required by Gemini CLI.
+
+        Returns:
+            Empty list (no special setup required)
+        """
+        return []
+
+    def get_default_model(self) -> str:
+        """Get the default model for Gemini CLI.
+
+        Returns:
+            Default model string
+        """
+        return os.getenv("BENCH_MODEL", "google/gemini-2.5-pro")
+
+    def get_description(self) -> str:
+        """Get description of Gemini CLI.
+
+        Returns:
+            Description string
+        """
+        return "gemini cli code agent"
+
+    def get_dockerfile_commands(self) -> List[str]:
+        """Get Dockerfile commands to install Gemini CLI.
+
+        Returns:
+            List of Dockerfile RUN commands
+        """
+        return GeminiCommands.DOCKERFILE_COMMANDS
+
+    def get_base_packages(self) -> List[str]:
+        """Get base packages required by Gemini CLI.
+
+        Returns:
+            List of apt package names
+        """
+        return GeminiCommands.BASE_PACKAGES
+
+    def get_env_requirements(self) -> List[str]:
+        """Get environment variables required by Gemini CLI.
+
+        Returns:
+            List of environment variable names
+        """
+        return ["GEMINI_API_KEY"]

--- a/src/openbench/agents/manager.py
+++ b/src/openbench/agents/manager.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional
 from .base import BaseCodeAgent
 from .aider import AiderAgent
 from .opencode import OpenCodeAgent
+from .gemini import GeminiAgent
 from .roo import RooAgent
 from .claude import ClaudeCodeAgent
 from .codex import CodexAgent
@@ -20,6 +21,7 @@ class AgentManager:
     _agents: Dict[str, Callable[[], BaseCodeAgent]] = {
         "aider": AiderAgent,
         "opencode": OpenCodeAgent,
+        "gemini": GeminiAgent,
         "claude_code": ClaudeCodeAgent,
         "codex": CodexAgent,
         "roo": RooAgent,

--- a/src/openbench/agents/manager.py
+++ b/src/openbench/agents/manager.py
@@ -9,8 +9,9 @@ from typing import Callable, Dict, List, Optional
 from .base import BaseCodeAgent
 from .aider import AiderAgent
 from .opencode import OpenCodeAgent
-from .claude import ClaudeAgent
 from .roo import RooAgent
+from .claude import ClaudeCodeAgent
+from .codex import CodexAgent
 
 
 class AgentManager:
@@ -19,7 +20,8 @@ class AgentManager:
     _agents: Dict[str, Callable[[], BaseCodeAgent]] = {
         "aider": AiderAgent,
         "opencode": OpenCodeAgent,
-        "claude": ClaudeAgent,
+        "claude_code": ClaudeCodeAgent,
+        "codex": CodexAgent,
         "roo": RooAgent,
     }
 
@@ -178,7 +180,7 @@ class AgentManager:
             Formatted help text describing all available code agents
         """
         agent_names = cls.get_supported_agents()
-        default_agent = "opencode"
+        default_agent = "codex"
 
         help_text = f"CLI code agent to use for code evaluation. Options: {', '.join(agent_names)} (default: {default_agent})"
         return help_text

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -6703,17 +6703,6 @@ EVAL_GROUPS = {
             "arabic_exams_social_science_primary_school",
         ],
     ),
-    "exercism": EvalGroup(
-        name="Exercism",
-        description="Aggregate of 5 Exercism coding tasks",
-        benchmarks=[
-            "exercism_go",
-            "exercism_java",
-            "exercism_javascript",
-            "exercism_python",
-            "exercism_rust",
-        ],
-    ),
     "anli": EvalGroup(
         name="ANLI",
         description="Aggregate of 3 ANLI rounds",

--- a/src/openbench/evals/exercism/exercism.py
+++ b/src/openbench/evals/exercism/exercism.py
@@ -26,7 +26,7 @@ COMPOSE_PATH = (TASK_DIR / "compose.yaml").resolve()
 @task
 def exercism(
     languages: Optional[List[str]] = None,
-    code_agent: str = "opencode",
+    code_agent: str = "codex",
     hide_tests: bool = False,
 ) -> Task:
     """

--- a/src/openbench/evals/exercism/exercism.py
+++ b/src/openbench/evals/exercism/exercism.py
@@ -37,8 +37,8 @@ def exercism(
         languages: List of programming languages to include (python, go, javascript, java, rust).
                   If None, includes all supported languages.
         code_agent: CLI code agent to use for code evaluation.
-                   Defaults to 'opencode'. Can also be set via --code-agent flag.
-                   Valid options: aider, opencode, claude, roo
+                   Defaults to 'codex'. Can also be set via --code-agent flag.
+                   Valid options: codex, aider, opencode, claude_code, roo
 
     Returns:
         Task configured for Exercism evaluation

--- a/src/openbench/evals/exercism/exercism.py
+++ b/src/openbench/evals/exercism/exercism.py
@@ -16,6 +16,7 @@ from openbench.solvers.exercism_solver import exercism_solver
 from openbench.scorers.exercism import exercism_scorer
 from openbench.agents import AgentManager
 from openbench.agents.docker_manager import DockerManager
+from openbench.utils.text import EXERCISM_HIDDEN_TEST_PROMPT
 
 
 TASK_DIR = Path(__file__).parent
@@ -26,6 +27,7 @@ COMPOSE_PATH = (TASK_DIR / "compose.yaml").resolve()
 def exercism(
     languages: Optional[List[str]] = None,
     code_agent: str = "opencode",
+    hide_tests: bool = False,
 ) -> Task:
     """
     Exercism: Multi-language coding benchmark.
@@ -39,6 +41,8 @@ def exercism(
         code_agent: CLI code agent to use for code evaluation.
                    Defaults to 'codex'. Can also be set via --code-agent flag.
                    Valid options: codex, aider, opencode, claude_code, roo
+        hide_tests: When True, run the agent in a sanitized copy that excludes
+                    Exercism test suites. Tests still execute against the full repo.
 
     Returns:
         Task configured for Exercism evaluation
@@ -60,6 +64,9 @@ def exercism(
         if not hasattr(sample, "metadata") or sample.metadata is None:
             sample.metadata = {}
         sample.metadata["code_agent"] = code_agent
+        sample.metadata["hide_tests"] = hide_tests
+        if hide_tests:
+            sample.input = EXERCISM_HIDDEN_TEST_PROMPT
 
     # Determine task name based on languages
     if languages and len(languages) == 1:
@@ -81,55 +88,57 @@ def exercism(
 
 
 @task
-def exercism_python(code_agent: str = "opencode") -> Task:
+def exercism_python(code_agent: str = "codex", hide_tests: bool = False) -> Task:
     """
     Exercism: Python coding tasks only.
 
     Returns:
         Task configured for Python-only Exercism evaluation
     """
-    return exercism(languages=["python"], code_agent=code_agent)
+    return exercism(languages=["python"], code_agent=code_agent, hide_tests=hide_tests)
 
 
 @task
-def exercism_javascript(code_agent: str = "opencode") -> Task:
+def exercism_javascript(code_agent: str = "codex", hide_tests: bool = False) -> Task:
     """
     Exercism: JavaScript coding tasks only.
 
     Returns:
         Task configured for JavaScript-only Exercism evaluation
     """
-    return exercism(languages=["javascript"], code_agent=code_agent)
+    return exercism(
+        languages=["javascript"], code_agent=code_agent, hide_tests=hide_tests
+    )
 
 
 @task
-def exercism_go(code_agent: str = "opencode") -> Task:
+def exercism_go(code_agent: str = "codex", hide_tests: bool = False) -> Task:
     """
     Exercism: Go coding tasks only.
 
     Returns:
         Task configured for Go-only Exercism evaluation
     """
-    return exercism(languages=["go"], code_agent=code_agent)
+    return exercism(languages=["go"], code_agent=code_agent, hide_tests=hide_tests)
 
 
 @task
-def exercism_java(code_agent: str = "opencode") -> Task:
+def exercism_java(code_agent: str = "codex", hide_tests: bool = False) -> Task:
     """
     Exercism: Java coding tasks only.
 
     Returns:
         Task configured for Java-only Exercism evaluation
     """
-    return exercism(languages=["java"], code_agent=code_agent)
+    return exercism(languages=["java"], code_agent=code_agent, hide_tests=hide_tests)
 
 
 @task
-def exercism_rust(code_agent: str = "opencode") -> Task:
+def exercism_rust(code_agent: str = "codex", hide_tests: bool = False) -> Task:
     """
     Exercism: Rust coding tasks only.
 
     Returns:
         Task configured for Rust-only Exercism evaluation
     """
-    return exercism(languages=["rust"], code_agent=code_agent)
+    return exercism(languages=["rust"], code_agent=code_agent, hide_tests=hide_tests)

--- a/src/openbench/provider_config.py
+++ b/src/openbench/provider_config.py
@@ -188,6 +188,7 @@ PROVIDER_CONFIGS: Dict[ProviderType, ProviderConfig] = {
         display_name="Google AI",
         api_key_env="GOOGLE_API_KEY",
         base_url="https://generativelanguage.googleapis.com/v1beta",
+        additional_env_vars=["GEMINI_API_KEY"],
         supports_vision=True,
         supports_function_calling=True,
     ),

--- a/src/openbench/solvers/exercism_solver.py
+++ b/src/openbench/solvers/exercism_solver.py
@@ -22,6 +22,7 @@ Usage:
 
 from __future__ import annotations
 
+from typing import Any, Dict
 
 from inspect_ai.solver import Solver, TaskState, solver
 from openbench.utils.cli_commands import (
@@ -29,6 +30,8 @@ from openbench.utils.cli_commands import (
     run_setup_commands,
     run_final_test,
     format_solver_output,
+    prepare_hidden_workspace,
+    sync_agent_workspace,
 )
 from openbench.agents import AgentManager
 
@@ -91,19 +94,49 @@ def exercism_solver() -> Solver:
                 )
                 return state
 
-            workdir = f"/workspace/{language}/{task_name}"
+            full_workdir = f"/workspace/{language}/{task_name}"
+            agent_workdir = full_workdir
+            hide_tests = bool(state.metadata.get("hide_tests"))
+            sync_context: Dict[str, Any] | None = None
+
+            if hide_tests:
+                prep_result = await prepare_hidden_workspace(language, task_name)
+                if not prep_result.get("success"):
+                    stderr = prep_result.get("stderr") or "unknown error"
+                    state.output.completion = (
+                        f"ERROR: Failed to prepare hidden workspace: {stderr}"
+                    )
+                    return state
+                agent_workdir = str(prep_result.get("agent_dir", full_workdir))
+                sync_context = {
+                    "hidden_paths": prep_result.get("hidden_paths", {}),
+                }
+
             prompt_text = state.input_text
 
             # Run any language-specific setup commands inside the task directory
-            setup_out = await run_setup_commands(setup_commands, workdir)
+            setup_out = await run_setup_commands(setup_commands, agent_workdir)
 
             agent = AgentManager.get_agent(code_agent)
 
             model = agent.resolve_model_with_fallback(str(state.model))
 
-            code_agent_out = await agent.execute(workdir, prompt_text, model)
+            code_agent_out = await agent.execute(agent_workdir, prompt_text, model)
 
-            test_out = await run_final_test(test_command, workdir)
+            if hide_tests and sync_context is not None:
+                sync_result = await sync_agent_workspace(
+                    agent_workdir,
+                    full_workdir,
+                    dict(sync_context.get("hidden_paths", {})),
+                )
+                if not sync_result.get("success"):
+                    stderr = sync_result.get("stderr") or "unknown error"
+                    state.output.completion = (
+                        f"ERROR: Failed to sync hidden workspace: {stderr}"
+                    )
+                    return state
+
+            test_out = await run_final_test(test_command, full_workdir)
 
             state.output.completion = format_solver_output(
                 code_agent, setup_out, code_agent_out, test_out

--- a/src/openbench/solvers/exercism_solver.py
+++ b/src/openbench/solvers/exercism_solver.py
@@ -1,19 +1,22 @@
 """
 Unified CLI solver for exercism tasks that supports multiple code agents.
 
-This solver provides a unified interface for different CLI code agents (aider, opencode, claude, roo)
+This solver provides a unified interface for different CLI code agents
+(codex, aider, opencode, claude_code, roo)
 and selects the appropriate tool based on the --code-agent flag or task arguments.
 
 Supported code agents:
+- codex: Codex CLI agent powered by inspect_swe (default)
 - aider: AI-powered pair programming tool with git integration
 - opencode: OpenAI-compatible code generation tool
-- claude: Claude-based code editor with file system access
+- claude_code: Claude Code editor powered by inspect_swe
 - roo: Roo extension for VS Code with interactive development
 
 Usage:
-    openbench eval exercism --code-agent aider --model groq/llama-3.1-70b
+    openbench eval exercism --code-agent codex --model openai/gpt-5
     openbench eval exercism --code-agent opencode --model openai/gpt-4o-mini
-    openbench eval exercism --code-agent claude --model anthropic/claude-sonnet-4-20250514
+    openbench eval exercism --code-agent claude_code --model anthropic/claude-sonnet-4-5-20250929
+    openbench eval exercism --code-agent aider --model groq/llama-3.1-70b
     openbench eval exercism --code-agent roo --model openrouter/anthropic/claude-sonnet-4-20250514
 """
 
@@ -39,8 +42,8 @@ def exercism_solver() -> Solver:
     the appropriate tool based on the code agent specified in task arguments.
 
     The code agent can be specified via:
-    - CLI flag: --code-agent aider|opencode|claude|roo
-    - Defaults to 'aider' if not specified
+    - CLI flag: --code-agent codex|aider|opencode|claude_code|roo
+    - Defaults to 'codex' if not specified
 
     Returns:
         Solver function that handles the task execution
@@ -63,13 +66,13 @@ def exercism_solver() -> Solver:
         if not isinstance(setup_commands, list):
             setup_commands = []
 
-        code_agent = state.metadata.get("code_agent", "aider")
+        code_agent = state.metadata.get("code_agent", "codex")
 
         # Validate code agent input
         if isinstance(code_agent, list) and len(code_agent) > 0:
             code_agent = code_agent[0]
         elif not isinstance(code_agent, str):
-            code_agent = "aider"
+            code_agent = "codex"
 
         code_agent = code_agent.lower()
 

--- a/src/openbench/utils/cli_commands.py
+++ b/src/openbench/utils/cli_commands.py
@@ -559,7 +559,7 @@ echo "Running Gemini CLI with prompt: $PROMPT"
 echo "Working directory: $(pwd)"
 
 # Run Gemini with --yolo flag to enable automatic file editing
-gemini -p "$PROMPT" --yolo 2>&1 | tee /tmp/gemini-output.log
+gemini --model {model} -p "$PROMPT" --yolo 2>&1 | tee /tmp/gemini-output.log
 """
 
 

--- a/src/openbench/utils/cli_commands.py
+++ b/src/openbench/utils/cli_commands.py
@@ -1,7 +1,8 @@
 """
 Utility functions for CLI-based solvers that run tasks inside Docker sandboxes.
 
-This module provides common functionality for different CLI code agents (aider, opencode, roo)
+This module provides common functionality for different CLI code agents
+(aider, opencode, claude_code, codex, roo)
 including repository management, environment setup, and command execution.
 """
 
@@ -392,33 +393,6 @@ opencode run -m {model} "$PROMPT" 2>&1 | tee /tmp/opencode-output.log
 """
 
 
-def get_claude_script_template() -> str:
-    """Get the Claude Code execution script template.
-
-    Returns:
-        Claude Code script template with placeholders
-    """
-    return """#!/bin/bash
-set +e
-
-cd {workdir}
-
-# Read the prompt from file
-PROMPT=$(cat /tmp/claude_code_prompt.txt)
-
-{env_setup}
-
-echo "Running Claude Code with prompt: $PROMPT"  
-echo "Model: {model}"
-echo "Working directory: $(pwd)"
-
-echo "$PROMPT" | claude -p --model "{model}" \
-    --permission-mode acceptEdits \
-    --allowedTools "Bash(*)" "Read" "Edit" \
-    2>&1 | tee /tmp/claude-code-output.log
-"""
-
-
 def get_roo_script_template() -> str:
     """Get the Roo CLI execution script template.
 
@@ -592,7 +566,8 @@ def format_solver_output(
     code_agent_section_map = {
         "aider": "AIDER_OUTPUT",
         "opencode": "OPENCODE_OUTPUT",
-        "claude": "CLAUDE_CODE_OUTPUT",
+        "claude_code": "CLAUDE_CODE_OUTPUT",
+        "codex": "CODEX_CLI_OUTPUT",
         "roo": "ROO_CLI_EXECUTION",
     }
 

--- a/src/openbench/utils/cli_commands.py
+++ b/src/openbench/utils/cli_commands.py
@@ -8,12 +8,19 @@ including repository management, environment setup, and command execution.
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shlex
 from typing import Any, Dict, List, Optional
 
 from inspect_ai.util import sandbox
 
 from openbench.provider_config import ProviderManager
+from openbench.utils.text import DISCOVER_TEST_FILES_SCRIPT
+
+
+AGENT_WORKSPACE_ROOT = "/workspace/.agent_workspaces"
 
 
 # =============================================================================
@@ -46,6 +53,139 @@ async def ensure_repo_and_task(language: str, task_name: str) -> bool:
         return result.returncode == 0
     except Exception:
         return False
+
+
+def _normalize_relative_path(path: str) -> str:
+    """Normalize a relative path for rsync exclude usage."""
+    if not path:
+        return ""
+    normalized = os.path.normpath(path)
+    if normalized == ".":
+        return ""
+    return normalized.lstrip("./")
+
+
+def _build_exclude_flags(hidden_paths: Dict[str, List[str]]) -> List[str]:
+    """Convert hidden path lists into rsync --exclude flags."""
+    flags: List[str] = []
+
+    for file_path in hidden_paths.get("files", []):
+        rel = _normalize_relative_path(file_path)
+        if not rel:
+            continue
+        flags.append(f"--exclude={shlex.quote(rel)}")
+
+    for dir_path in hidden_paths.get("dirs", []):
+        rel = _normalize_relative_path(dir_path)
+        if not rel:
+            continue
+        rel_dir = rel.rstrip("/")
+        flags.append(f"--exclude={shlex.quote(rel_dir)}")
+        flags.append(f"--exclude={shlex.quote(rel_dir + '/**')}")
+
+    return flags
+
+
+async def discover_hidden_paths(full_dir: str) -> Dict[str, Any]:
+    """Detect test files and directories."""
+    script = DISCOVER_TEST_FILES_SCRIPT.format(root_dir=full_dir)
+
+    result = await sandbox().exec(
+        cmd=["bash", "-lc", script],
+        timeout=120,
+    )
+
+    if result.returncode != 0:
+        return {
+            "success": False,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "failed to detect hidden paths",
+        }
+
+    stdout = result.stdout.strip() or "{}"
+    try:
+        hidden_paths = json.loads(stdout)
+        hidden_paths.setdefault("dirs", [])
+        hidden_paths.setdefault("files", [])
+    except json.JSONDecodeError as exc:
+        return {
+            "success": False,
+            "stdout": stdout,
+            "stderr": f"failed to parse hidden path output: {exc}",
+        }
+
+    return {
+        "success": True,
+        "hidden_paths": hidden_paths,
+    }
+
+
+async def prepare_hidden_workspace(language: str, task_name: str) -> Dict[str, Any]:
+    """Create a sanitized workspace copy with tests removed."""
+    full_dir = f"/workspace/{language}/{task_name}"
+    agent_dir = os.path.join(AGENT_WORKSPACE_ROOT, language, task_name)
+    discovery = await discover_hidden_paths(full_dir)
+    if not discovery.get("success"):
+        return discovery
+
+    hidden_paths: Dict[str, List[str]] = discovery.get("hidden_paths", {})
+    exclude_flags = _build_exclude_flags(hidden_paths)
+    exclude_args = " ".join(exclude_flags)
+
+    if exclude_args:
+        rsync_cmd = f'rsync -a --delete {exclude_args} "{full_dir}/" "{agent_dir}/"'
+    else:
+        rsync_cmd = f'rsync -a --delete "{full_dir}/" "{agent_dir}/"'
+
+    script_lines = [
+        "set -euo pipefail",
+        f"rm -rf {shlex.quote(agent_dir)}",
+        f"mkdir -p {shlex.quote(agent_dir)}",
+        rsync_cmd,
+    ]
+
+    result = await sandbox().exec(
+        cmd=["bash", "-lc", "\n".join(script_lines)],
+        timeout=240,
+    )
+
+    return {
+        "success": result.returncode == 0,
+        "agent_dir": agent_dir,
+        "hidden_paths": hidden_paths,
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+    }
+
+
+async def sync_agent_workspace(
+    agent_dir: str, full_dir: str, hidden_paths: Dict[str, List[str]]
+) -> Dict[str, Any]:
+    """Propagate changes from the sanitized workspace back into the full repo for grading."""
+    exclude_flags = _build_exclude_flags(hidden_paths)
+    exclude_args = " ".join(exclude_flags)
+    if exclude_args:
+        rsync_cmd = f'rsync -a --delete {exclude_args} "{agent_dir}/" "{full_dir}/"'
+    else:
+        rsync_cmd = f'rsync -a --delete "{agent_dir}/" "{full_dir}/"'
+
+    script_lines = [
+        "set -euo pipefail",
+        f"test -d {shlex.quote(agent_dir)}",
+        f"test -d {shlex.quote(full_dir)}",
+        rsync_cmd,
+    ]
+
+    result = await sandbox().exec(
+        cmd=["bash", "-lc", "\n".join(script_lines)],
+        timeout=240,
+    )
+
+    return {
+        "success": result.returncode == 0,
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+    }
 
 
 async def run_setup_commands(setup_commands: List[str], workdir: str) -> str:
@@ -393,6 +533,36 @@ opencode run -m {model} "$PROMPT" 2>&1 | tee /tmp/opencode-output.log
 """
 
 
+def get_gemini_script_template() -> str:
+    """Get the Gemini CLI execution script template.
+
+    Returns:
+        Gemini script template with placeholders
+    """
+    return """#!/bin/bash
+set +e
+
+cd {workdir}
+
+# Read the prompt from file
+PROMPT=$(cat /tmp/gemini_prompt.txt)
+
+{env_setup}
+
+# Map GOOGLE_API_KEY to GEMINI_API_KEY if GEMINI_API_KEY is not set
+if [ -z "$GEMINI_API_KEY" ] && [ -n "$GOOGLE_API_KEY" ]; then
+    export GEMINI_API_KEY="$GOOGLE_API_KEY"
+    echo "Mapped GOOGLE_API_KEY to GEMINI_API_KEY"
+fi
+
+echo "Running Gemini CLI with prompt: $PROMPT"
+echo "Working directory: $(pwd)"
+
+# Run Gemini with --yolo flag to enable automatic file editing
+gemini -p "$PROMPT" --yolo 2>&1 | tee /tmp/gemini-output.log
+"""
+
+
 def get_roo_script_template() -> str:
     """Get the Roo CLI execution script template.
 
@@ -569,6 +739,7 @@ def format_solver_output(
         "claude_code": "CLAUDE_CODE_OUTPUT",
         "codex": "CODEX_CLI_OUTPUT",
         "roo": "ROO_CLI_EXECUTION",
+        "gemini": "GEMINI_OUTPUT",
     }
 
     code_agent_section = code_agent_section_map.get(

--- a/src/openbench/utils/docker.py
+++ b/src/openbench/utils/docker.py
@@ -105,14 +105,6 @@ class OpenCodeCommands:
     BASE_PACKAGES = ["curl", "gnupg", "ca-certificates"]
 
 
-class ClaudeCommands:
-    """Docker commands for Claude agent installation."""
-
-    DOCKERFILE_COMMANDS = ["RUN npm install -g @anthropic-ai/claude-code"]
-
-    BASE_PACKAGES = ["curl", "gnupg", "ca-certificates"]
-
-
 class RooCommands:
     """Docker commands for Roo agent installation."""
 
@@ -250,7 +242,8 @@ def get_agent_docker_commands(agent_name: str) -> List[str]:
     commands_map = {
         "aider": AiderCommands.DOCKERFILE_COMMANDS,
         "opencode": OpenCodeCommands.DOCKERFILE_COMMANDS,
-        "claude": ClaudeCommands.DOCKERFILE_COMMANDS,
+        "claude_code": [],
+        "codex": [],
         "roo": RooCommands.get_dockerfile_commands(),
     }
 
@@ -275,7 +268,8 @@ def get_agent_base_packages(agent_name: str) -> List[str]:
     packages_map = {
         "aider": AiderCommands.BASE_PACKAGES,
         "opencode": OpenCodeCommands.BASE_PACKAGES,
-        "claude": ClaudeCommands.BASE_PACKAGES,
+        "claude_code": [],
+        "codex": [],
         "roo": RooCommands.BASE_PACKAGES,
     }
 

--- a/src/openbench/utils/docker.py
+++ b/src/openbench/utils/docker.py
@@ -61,6 +61,7 @@ COMMON_BASE_PACKAGES = [
     "jq",
     "xz-utils",
     "bash",
+    "rsync",
 ]
 
 # Language runtime packages for exercism support
@@ -101,6 +102,14 @@ class OpenCodeCommands:
     """Docker commands for OpenCode agent installation."""
 
     DOCKERFILE_COMMANDS = ["RUN npm install -g opencode-ai"]
+
+    BASE_PACKAGES = ["curl", "gnupg", "ca-certificates"]
+
+
+class GeminiCommands:
+    """Docker commands for Gemini CLI agent installation."""
+
+    DOCKERFILE_COMMANDS = ["RUN npm install -g @google/gemini-cli@latest"]
 
     BASE_PACKAGES = ["curl", "gnupg", "ca-certificates"]
 
@@ -242,6 +251,7 @@ def get_agent_docker_commands(agent_name: str) -> List[str]:
     commands_map = {
         "aider": AiderCommands.DOCKERFILE_COMMANDS,
         "opencode": OpenCodeCommands.DOCKERFILE_COMMANDS,
+        "gemini": GeminiCommands.DOCKERFILE_COMMANDS,
         "claude_code": [],
         "codex": [],
         "roo": RooCommands.get_dockerfile_commands(),
@@ -268,6 +278,7 @@ def get_agent_base_packages(agent_name: str) -> List[str]:
     packages_map = {
         "aider": AiderCommands.BASE_PACKAGES,
         "opencode": OpenCodeCommands.BASE_PACKAGES,
+        "gemini": GeminiCommands.BASE_PACKAGES,
         "claude_code": [],
         "codex": [],
         "roo": RooCommands.BASE_PACKAGES,

--- a/src/openbench/utils/text.py
+++ b/src/openbench/utils/text.py
@@ -208,6 +208,19 @@ You are an expert AI technical writer. Based on the following information about 
 Please return only the generated summary text, without any additional titles or preambles.
 """
 
+
+EXERCISM_HIDDEN_TEST_PROMPT = """
+Your job is to complete a coding exercise described in the markdown files inside the `docs` directory.
+
+A file with the implementation stubbed out has been created for you, along with the surrounding project scaffolding.
+
+To successfully complete the exercise, implement the required functionality so the solution satisfies the specification.
+
+Tests have been hidden from you and you will not be able to run them. Complete the exercise to the best of your ability based on the instructions.
+
+You should start by reading the files in the `docs` directory so that you understand the exercise, and then examine the stubbed out implementation.
+""".strip()
+
 LIVEMCPBENCH_VERDICT_PATTERN = re.compile(
     r"Thoughts:\s*(.+?)\s*Status:\s*(\w+)", re.DOTALL
 )
@@ -217,7 +230,7 @@ Please solve this AIME problem step by step. The answer is an integer ranging fr
 
 {question}
 
-Remember to show your work clearly and end with ‘ANSWER: X’ where X is your final numerical answer.
+Remember to show your work clearly and end with 'ANSWER: X' where X is your final numerical answer.
 """
 
 
@@ -589,3 +602,40 @@ which provides domain filtering capabilities.
 """
 # Expected SHA-256 hash for factscore db
 FACTSCORE_DB_SHA256 = "31cf7b6b4465459844bb00f3a6ac75560fc7d1525112205a21859323dc5d33d7"
+
+# Python script template for discovering test files and directories in exercism tasks
+DISCOVER_TEST_FILES_SCRIPT = """python3 - <<'PY'
+import json
+import os
+
+root = {root_dir!r}
+root = os.path.abspath(root)
+dir_matches = set()
+file_matches = set()
+
+for current, dirnames, filenames in os.walk(root):
+    rel_current = os.path.relpath(current, root)
+    rel_current = "" if rel_current == "." else rel_current
+
+    keep_dirs = []
+    for dirname in dirnames:
+        rel_path = os.path.join(rel_current, dirname) if rel_current else dirname
+        if "test" in dirname.lower():
+            dir_matches.add(rel_path)
+        else:
+            keep_dirs.append(dirname)
+    dirnames[:] = keep_dirs
+
+    for filename in filenames:
+        lowered = filename.lower()
+        if "test" in lowered or lowered.endswith(".spec.js"):
+            rel_path = os.path.join(rel_current, filename) if rel_current else filename
+            file_matches.add(rel_path)
+
+result = {{
+    "dirs": sorted(dir_matches),
+    "files": sorted(file_matches),
+}}
+
+print(json.dumps(result))
+PY"""

--- a/tests/test_exercism_cli.py
+++ b/tests/test_exercism_cli.py
@@ -1,0 +1,470 @@
+"""Tests for Exercism-specific CLI helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from openbench.utils import cli_commands
+
+
+class _RecordingSandbox:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+        self.commands.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+class _LocalSandbox:
+    async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+        completed = await asyncio.to_thread(
+            subprocess.run,
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return SimpleNamespace(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_detects_spec_js(tmp_path, monkeypatch):
+    """Ensure .spec.js files are treated as hidden test files."""
+    task_dir = tmp_path / "javascript" / "two-fer"
+    (task_dir / "src").mkdir(parents=True)
+    (task_dir / "src" / "two_fer.spec.js").write_text("// spec file")
+
+    local_sandbox = _LocalSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: local_sandbox)
+
+    result = await cli_commands.discover_hidden_paths(str(task_dir))
+
+    assert result["success"] is True
+    hidden_files = result["hidden_paths"]["files"]
+    assert "src/two_fer.spec.js" in hidden_files
+
+
+@pytest.mark.asyncio
+async def test_prepare_hidden_workspace_builds_excludes(monkeypatch):
+    """prepare_hidden_workspace should exclude discovered test artifacts."""
+
+    async def fake_discover(path: str):
+        assert path == "/workspace/javascript/two-fer"
+        return {
+            "success": True,
+            "hidden_paths": {"files": ["src/two_fer.spec.js"], "dirs": []},
+        }
+
+    recording_sandbox = _RecordingSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: recording_sandbox)
+    monkeypatch.setattr(cli_commands, "discover_hidden_paths", fake_discover)
+
+    result = await cli_commands.prepare_hidden_workspace("javascript", "two-fer")
+
+    assert result["success"] is True
+    assert result["agent_dir"].endswith("/javascript/two-fer")
+    # Verify rsync command contains exclude flag for the spec file
+    rsync_script = recording_sandbox.commands[-1][2]
+    assert "--exclude=src/two_fer.spec.js" in rsync_script
+
+
+@pytest.mark.asyncio
+async def test_sync_agent_workspace_respects_hidden_paths(monkeypatch):
+    """sync_agent_workspace should keep hidden paths excluded during sync."""
+    recording_sandbox = _RecordingSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: recording_sandbox)
+
+    hidden_paths = {"files": ["src/two_fer.spec.js"], "dirs": ["testdata"]}
+
+    result = await cli_commands.sync_agent_workspace(
+        "/tmp/agent", "/tmp/full", hidden_paths
+    )
+
+    assert result["success"] is True
+    script = recording_sandbox.commands[-1][2]
+    assert "--exclude=src/two_fer.spec.js" in script
+    assert "--exclude=testdata" in script
+    assert "--exclude='testdata/**'" in script
+
+
+# =============================================================================
+# Unit Tests for Helper Functions
+# =============================================================================
+
+
+def test_normalize_relative_path_edge_cases():
+    """Test path normalization edge cases."""
+    from openbench.utils.cli_commands import _normalize_relative_path
+
+    # Empty string
+    assert _normalize_relative_path("") == ""
+
+    # Current directory
+    assert _normalize_relative_path(".") == ""
+    assert _normalize_relative_path("./") == ""
+
+    # Leading ./ should be stripped
+    assert _normalize_relative_path("./src/file.py") == "src/file.py"
+
+    # Nested paths with ..
+    assert _normalize_relative_path("./foo/../bar") == "bar"
+
+    # Already normalized paths
+    assert _normalize_relative_path("src/test/file.py") == "src/test/file.py"
+
+    # Trailing slashes
+    assert _normalize_relative_path("./src/") == "src"
+
+
+def test_build_exclude_flags_empty_inputs():
+    """Test exclude flag building with empty inputs."""
+    from openbench.utils.cli_commands import _build_exclude_flags
+
+    # Empty dict
+    assert _build_exclude_flags({}) == []
+
+    # Empty files and dirs
+    assert _build_exclude_flags({"files": [], "dirs": []}) == []
+
+
+def test_build_exclude_flags_files_only():
+    """Test exclude flags with only files."""
+    from openbench.utils.cli_commands import _build_exclude_flags
+
+    flags = _build_exclude_flags({"files": ["test_file.py", "src/test.js"], "dirs": []})
+
+    assert len(flags) == 2
+    assert "--exclude=test_file.py" in flags
+    assert "--exclude=src/test.js" in flags
+
+
+def test_build_exclude_flags_dirs_only():
+    """Test exclude flags with only directories."""
+    from openbench.utils.cli_commands import _build_exclude_flags
+
+    flags = _build_exclude_flags({"files": [], "dirs": ["tests", "src/test_data"]})
+
+    # Each dir should have 2 flags (dir itself and dir/**)
+    assert len(flags) == 4
+    assert "--exclude=tests" in flags
+    assert "--exclude='tests/**'" in flags
+
+
+def test_build_exclude_flags_skips_empty_paths():
+    """Test that empty paths are skipped."""
+    from openbench.utils.cli_commands import _build_exclude_flags
+
+    flags = _build_exclude_flags(
+        {"files": ["", "valid.py", "."], "dirs": ["", ".", "valid_dir"]}
+    )
+
+    # Should only include valid paths
+    assert "--exclude=valid.py" in flags
+    assert "--exclude=valid_dir" in flags
+
+
+# =============================================================================
+# Additional discover_hidden_paths Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_detects_test_dirs(tmp_path, monkeypatch):
+    """Ensure directories with 'test' in name are detected."""
+    task_dir = tmp_path / "python" / "task"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "src").mkdir(parents=True)
+    (task_dir / "src" / "test_utils").mkdir(parents=True)
+
+    local_sandbox = _LocalSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: local_sandbox)
+
+    result = await cli_commands.discover_hidden_paths(str(task_dir))
+
+    assert result["success"] is True
+    hidden_dirs = result["hidden_paths"]["dirs"]
+    assert "tests" in hidden_dirs
+    assert "src/test_utils" in hidden_dirs
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_case_insensitive(tmp_path, monkeypatch):
+    """Ensure detection is case-insensitive."""
+    task_dir = tmp_path / "task"
+    task_dir.mkdir(parents=True)
+    (task_dir / "TEST_file.py").write_text("")
+    (task_dir / "Test_Dir").mkdir()
+
+    local_sandbox = _LocalSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: local_sandbox)
+
+    result = await cli_commands.discover_hidden_paths(str(task_dir))
+
+    assert result["success"] is True
+    assert "TEST_file.py" in result["hidden_paths"]["files"]
+    assert "Test_Dir" in result["hidden_paths"]["dirs"]
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_handles_script_failure(monkeypatch):
+    """Test error handling when script fails."""
+
+    class FailingSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            return SimpleNamespace(returncode=1, stdout="", stderr="Python error")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: FailingSandbox())
+
+    result = await cli_commands.discover_hidden_paths("/some/path")
+
+    assert result["success"] is False
+    assert "stderr" in result
+    assert "Python error" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_handles_invalid_json(monkeypatch):
+    """Test error handling when JSON parsing fails."""
+
+    class BadJsonSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            return SimpleNamespace(returncode=0, stdout="not valid json{", stderr="")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: BadJsonSandbox())
+
+    result = await cli_commands.discover_hidden_paths("/some/path")
+
+    assert result["success"] is False
+    assert "failed to parse" in result["stderr"]
+
+
+@pytest.mark.asyncio
+async def test_discover_hidden_paths_no_test_files(tmp_path, monkeypatch):
+    """Test with directory containing no test files."""
+    task_dir = tmp_path / "clean_task"
+    task_dir.mkdir(parents=True)
+    (task_dir / "main.py").write_text("")
+    (task_dir / "utils.py").write_text("")
+
+    local_sandbox = _LocalSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: local_sandbox)
+
+    result = await cli_commands.discover_hidden_paths(str(task_dir))
+
+    assert result["success"] is True
+    assert result["hidden_paths"]["files"] == []
+    assert result["hidden_paths"]["dirs"] == []
+
+
+# =============================================================================
+# prepare_hidden_workspace Error Handling Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_prepare_hidden_workspace_propagates_discovery_failure(monkeypatch):
+    """Test that discovery failures are propagated."""
+
+    async def failing_discover(path: str):
+        return {"success": False, "stdout": "", "stderr": "Discovery failed"}
+
+    monkeypatch.setattr(cli_commands, "discover_hidden_paths", failing_discover)
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: _RecordingSandbox())
+
+    result = await cli_commands.prepare_hidden_workspace("python", "task")
+
+    assert result["success"] is False
+    assert result["stderr"] == "Discovery failed"
+
+
+@pytest.mark.asyncio
+async def test_prepare_hidden_workspace_no_excludes(monkeypatch):
+    """Test workspace preparation when no test files found."""
+
+    async def clean_discover(path: str):
+        return {"success": True, "hidden_paths": {"files": [], "dirs": []}}
+
+    recording_sandbox = _RecordingSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: recording_sandbox)
+    monkeypatch.setattr(cli_commands, "discover_hidden_paths", clean_discover)
+
+    result = await cli_commands.prepare_hidden_workspace("python", "task")
+
+    assert result["success"] is True
+    # Verify rsync command doesn't have --exclude flags
+    rsync_script = recording_sandbox.commands[-1][2]
+    assert "--exclude" not in rsync_script
+
+
+# =============================================================================
+# run_setup_commands Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_setup_commands_empty_list(monkeypatch):
+    """Test with no setup commands."""
+    result = await cli_commands.run_setup_commands([], "/workspace/task")
+    assert result == "No setup commands"
+
+
+@pytest.mark.asyncio
+async def test_run_setup_commands_success(monkeypatch):
+    """Test successful setup command execution."""
+
+    class SuccessSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            return SimpleNamespace(returncode=0, stdout="Setup complete", stderr="")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: SuccessSandbox())
+
+    result = await cli_commands.run_setup_commands(
+        ["pip install -r requirements.txt"], "/workspace/task"
+    )
+
+    assert "Exit Code: 0" in result
+    assert "Success: True" in result
+    assert "Setup complete" in result
+
+
+@pytest.mark.asyncio
+async def test_run_setup_commands_failure(monkeypatch):
+    """Test setup command failure."""
+
+    class FailingSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            return SimpleNamespace(returncode=1, stdout="", stderr="Package not found")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: FailingSandbox())
+
+    result = await cli_commands.run_setup_commands(
+        ["pip install nonexistent"], "/workspace/task"
+    )
+
+    assert "Exit Code: 1" in result
+    assert "Success: False" in result
+    assert "Package not found" in result
+
+
+# =============================================================================
+# run_final_test Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_final_test_python_filename_normalization(monkeypatch):
+    """Test Python test filename normalization (hyphens to underscores)."""
+
+    class RecordingCommandSandbox:
+        def __init__(self):
+            self.last_cmd = None
+
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            self.last_cmd = cmd
+            return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    sandbox = RecordingCommandSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: sandbox)
+
+    await cli_commands.run_final_test(
+        "pytest two-fer-test.py", "/workspace/python/two-fer"
+    )
+
+    # Verify hyphens were converted to underscores
+    assert "two_fer_test.py" in sandbox.last_cmd[2]
+
+
+@pytest.mark.asyncio
+async def test_run_final_test_non_python_unchanged(monkeypatch):
+    """Test that non-Python tests don't get filename changes."""
+
+    class RecordingCommandSandbox:
+        def __init__(self):
+            self.last_cmd = None
+
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            self.last_cmd = cmd
+            return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    sandbox = RecordingCommandSandbox()
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: sandbox)
+
+    await cli_commands.run_final_test(
+        "npm test two-fer-test.js", "/workspace/javascript/two-fer"
+    )
+
+    # Verify filename was NOT changed (no python in path)
+    assert "two-fer-test.js" in sandbox.last_cmd[2]
+
+
+@pytest.mark.asyncio
+async def test_run_final_test_exception_handling(monkeypatch):
+    """Test exception handling in test execution."""
+
+    class ExceptionSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            raise RuntimeError("Sandbox crashed")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: ExceptionSandbox())
+
+    result = await cli_commands.run_final_test("pytest test.py", "/workspace/task")
+
+    assert "ERROR: test run failed" in result
+    assert "Sandbox crashed" in result
+
+
+# =============================================================================
+# ensure_repo_and_task Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_ensure_repo_and_task_success(monkeypatch):
+    """Test successful repo and task verification."""
+
+    class SuccessSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: SuccessSandbox())
+
+    result = await cli_commands.ensure_repo_and_task("python", "two-fer")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_repo_and_task_missing_task(monkeypatch):
+    """Test with missing task directory."""
+
+    class FailingSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            # Fail on the task existence check
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: FailingSandbox())
+
+    result = await cli_commands.ensure_repo_and_task("python", "nonexistent")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_repo_and_task_exception(monkeypatch):
+    """Test exception handling."""
+
+    class ExceptionSandbox:
+        async def exec(self, cmd, timeout=0, env=None):  # type: ignore[override]
+            raise Exception("Connection failed")
+
+    monkeypatch.setattr(cli_commands, "sandbox", lambda: ExceptionSandbox())
+
+    result = await cli_commands.ensure_repo_and_task("python", "task")
+    assert result is False

--- a/tests/test_groq_provider.py
+++ b/tests/test_groq_provider.py
@@ -143,31 +143,31 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 model_args = {"stream": True, "other_arg": "value"}
-                
+
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 # Stream parameter should be extracted and set
                 assert groq_api.stream is True
-                
+
     def test_stream_parameter_extraction_false(self):
         """Test that stream=False is properly extracted from model args."""
         with patch("httpx.AsyncClient"):
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 model_args = {"stream": False, "other_arg": "value"}
-                
+
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 # Stream parameter should be extracted and set
                 assert groq_api.stream is False
 
@@ -177,14 +177,14 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 model_args = {"other_arg": "value"}
-                
+
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 # Stream parameter should default to True
                 assert groq_api.stream is True
 
@@ -194,14 +194,14 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq") as mock_groq:
                 config = GenerateConfig()
                 model_args = {"stream": True, "other_arg": "value"}
-                
+
                 GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 # Verify AsyncGroq was called without the stream parameter
                 mock_groq.assert_called_once()
                 call_kwargs = mock_groq.call_args[1]
@@ -214,14 +214,14 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 model_args = {"stream": True}
-                
+
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 params = groq_api.completion_params(config)
                 assert params["stream"] is True
 
@@ -231,14 +231,14 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 model_args = {}  # No stream parameter specified
-                
+
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    **model_args
+                    **model_args,
                 )
-                
+
                 params = groq_api.completion_params(config)
                 assert params["stream"] is True
 
@@ -248,12 +248,12 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    stream=True
+                    stream=True,
                 )
-                
+
                 # Create mock stream chunks
                 chunk1 = MagicMock()
                 chunk1.choices = [MagicMock()]
@@ -266,7 +266,7 @@ class TestGroqProviderStreaming:
                 chunk1.model = "test-model"
                 chunk1.system_fingerprint = "test-fingerprint"
                 chunk1.created = 1234567890
-                
+
                 chunk2 = MagicMock()
                 chunk2.choices = [MagicMock()]
                 chunk2.choices[0].delta.content = "world!"
@@ -275,13 +275,13 @@ class TestGroqProviderStreaming:
                 chunk2.choices[0].delta.executed_tools = None
                 chunk2.choices[0].finish_reason = "stop"
                 chunk2.id = "test-id"
-                
+
                 # Mock async iterator
                 mock_stream = AsyncMock()
                 mock_stream.__aiter__.return_value = [chunk1, chunk2]
-                
+
                 result = await groq_api._handle_streaming_response(mock_stream, [])
-                
+
                 # Verify content was accumulated
                 assert result.choices[0].message.content == "Hello world!"
                 assert result.choices[0].finish_reason == "stop"
@@ -294,12 +294,12 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    stream=True
+                    stream=True,
                 )
-                
+
                 # Create mock stream chunks with reasoning
                 chunk1 = MagicMock()
                 chunk1.choices = [MagicMock()]
@@ -310,7 +310,7 @@ class TestGroqProviderStreaming:
                 chunk1.choices[0].finish_reason = None
                 chunk1.id = "test-id"
                 chunk1.model = "test-model"
-                
+
                 chunk2 = MagicMock()
                 chunk2.choices = [MagicMock()]
                 chunk2.choices[0].delta.content = None
@@ -318,14 +318,17 @@ class TestGroqProviderStreaming:
                 chunk2.choices[0].delta.tool_calls = None
                 chunk2.choices[0].delta.executed_tools = None
                 chunk2.choices[0].finish_reason = "stop"
-                
+
                 mock_stream = AsyncMock()
                 mock_stream.__aiter__.return_value = [chunk1, chunk2]
-                
+
                 result = await groq_api._handle_streaming_response(mock_stream, [])
-                
+
                 # Verify reasoning was accumulated
-                assert result.choices[0].message.reasoning == "First reasoning second reasoning"
+                assert (
+                    result.choices[0].message.reasoning
+                    == "First reasoning second reasoning"
+                )
 
     async def test_handle_streaming_response_tool_calls_accumulation(self):
         """Test that streaming response properly accumulates tool calls."""
@@ -333,12 +336,12 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    stream=True
+                    stream=True,
                 )
-                
+
                 # Create mock stream chunks with tool calls
                 tool_call1 = MagicMock()
                 tool_call1.index = 0
@@ -346,14 +349,14 @@ class TestGroqProviderStreaming:
                 tool_call1.type = "function"
                 tool_call1.function.name = "test_func"
                 tool_call1.function.arguments = '{"param":'
-                
+
                 tool_call2 = MagicMock()
                 tool_call2.index = 0
                 tool_call2.id = None
                 tool_call2.type = None
                 tool_call2.function.name = None
                 tool_call2.function.arguments = ' "value"}'
-                
+
                 chunk1 = MagicMock()
                 chunk1.choices = [MagicMock()]
                 chunk1.choices[0].delta.content = None
@@ -363,7 +366,7 @@ class TestGroqProviderStreaming:
                 chunk1.choices[0].finish_reason = None
                 chunk1.id = "test-id"
                 chunk1.model = "test-model"
-                
+
                 chunk2 = MagicMock()
                 chunk2.choices = [MagicMock()]
                 chunk2.choices[0].delta.content = None
@@ -371,12 +374,12 @@ class TestGroqProviderStreaming:
                 chunk2.choices[0].delta.tool_calls = [tool_call2]
                 chunk2.choices[0].delta.executed_tools = None
                 chunk2.choices[0].finish_reason = "tool_calls"
-                
+
                 mock_stream = AsyncMock()
                 mock_stream.__aiter__.return_value = [chunk1, chunk2]
-                
+
                 result = await groq_api._handle_streaming_response(mock_stream, [])
-                
+
                 # Verify tool call was accumulated
                 assert len(result.choices[0].message.tool_calls) == 1
                 tool_call = result.choices[0].message.tool_calls[0]
@@ -391,18 +394,18 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    stream=True
+                    stream=True,
                 )
-                
+
                 # Empty stream
                 mock_stream = AsyncMock()
                 mock_stream.__aiter__.return_value = []
-                
+
                 result = await groq_api._handle_streaming_response(mock_stream, [])
-                
+
                 # Should return valid but empty response
                 assert result.choices[0].message.content == ""
                 assert result.choices[0].message.reasoning is None
@@ -414,12 +417,12 @@ class TestGroqProviderStreaming:
             with patch("openbench.model._providers.groq.AsyncGroq"):
                 config = GenerateConfig()
                 groq_api = GroqAPI(
-                    model_name="test-model", 
-                    api_key="test-key", 
+                    model_name="test-model",
+                    api_key="test-key",
                     config=config,
-                    stream=True
+                    stream=True,
                 )
-                
+
                 # Create chunk with x_groq usage
                 chunk = MagicMock()
                 chunk.choices = []
@@ -428,11 +431,11 @@ class TestGroqProviderStreaming:
                 chunk.x_groq.usage.prompt_tokens = 10
                 chunk.x_groq.usage.completion_tokens = 20
                 chunk.x_groq.usage.total_tokens = 30
-                
+
                 mock_stream = AsyncMock()
                 mock_stream.__aiter__.return_value = [chunk]
-                
+
                 result = await groq_api._handle_streaming_response(mock_stream, [])
-                
+
                 # Verify usage was extracted
                 assert result.usage == chunk.x_groq.usage

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.73.0"
+version = "0.74.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -206,9 +206,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/07/f550112c3f5299d02f06580577f602e8a112b1988ad7c98ac1a8f7292d7e/anthropic-0.73.0.tar.gz", hash = "sha256:30f0d7d86390165f86af6ca7c3041f8720bb2e1b0e12a44525c8edfdbd2c5239", size = 425168, upload-time = "2025-11-14T18:47:52.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/7b/609eea5c54ae69b1a4a94169d4b0c86dc5c41b43509989913f6cdc61b81d/anthropic-0.74.1.tar.gz", hash = "sha256:04c087b2751385c524f6d332d066a913870e4de8b3e335fb0a0c595f1f88dc6e", size = 428981, upload-time = "2025-11-19T22:17:31.533Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b1/5d4d3f649e151e58dc938cf19c4d0cd19fca9a986879f30fea08a7b17138/anthropic-0.73.0-py3-none-any.whl", hash = "sha256:0d56cd8b3ca3fea9c9b5162868bdfd053fbc189b8b56d4290bd2d427b56db769", size = 367839, upload-time = "2025-11-14T18:47:51.195Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/6b18d0692302b8cbc01a10c35b43953d3c4172fbd4f83337b8ed21a8eaa4/anthropic-0.74.1-py3-none-any.whl", hash = "sha256:b07b998d1cee7f41d9f02530597d7411672b362cc2417760a40c0167b81c6e65", size = 371473, upload-time = "2025-11-19T22:17:29.998Z" },
 ]
 
 [[package]]
@@ -1423,13 +1423,14 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.125"
+version = "0.3.141"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioboto3" },
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "click" },
     { name = "debugpy" },
     { name = "docstring-parser" },
@@ -1458,11 +1459,31 @@ dependencies = [
     { name = "tenacity" },
     { name = "textual" },
     { name = "typing-extensions" },
+    { name = "universal-pathlib" },
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/9a/1a72dddd91503a87a64049b0f2b0012759624e6a1435b65e03803f265813/inspect_ai-0.3.125.tar.gz", hash = "sha256:2aeb491dc8cf03689e3080b642016d10aa5431867e1b8dbedcfe439a8f256fe8", size = 11900429, upload-time = "2025-08-25T13:32:36.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/d0/fcb7209b9e1b4a49a534de8bc7c12954830906756ff079782f0a2c80ae76/inspect_ai-0.3.141.tar.gz", hash = "sha256:4d82e289c8e4ea241a99c780a54ff5e3f546abdbe2a6c24dbbf4f53ffcf09631", size = 42787335, upload-time = "2025-10-27T11:57:05.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/d8/dc509a17c29db0132e9ad96072a1052eec30d0f3f8f89ccbbf100cddabb0/inspect_ai-0.3.125-py3-none-any.whl", hash = "sha256:ac1113744b63a5b74364160446a5a9671ca4b393113ba4fcc4fee09380e38cca", size = 3290751, upload-time = "2025-08-25T13:32:31.31Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/afbed4ccb75c9864599ed571b5e0a06bb105e2d75f72e35d0f89e6761b12/inspect_ai-0.3.141-py3-none-any.whl", hash = "sha256:22339ee9619619770bca451274ff23af39a7e309ea412f2051adfdf2e7d7731d", size = 34133970, upload-time = "2025-10-27T11:56:56.99Z" },
+]
+
+[[package]]
+name = "inspect-swe"
+version = "0.2.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "inspect-ai" },
+    { name = "nest-asyncio" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/35/d0234d0588c99c75ebdbbd02a6ce6fe82c958a0236589132a3f4a45dcb96/inspect_swe-0.2.26.tar.gz", hash = "sha256:811fcb299170980ec77f774a2c6c43b2875e9728c6054d700a93d83335932103", size = 16854, upload-time = "2025-11-15T20:37:25.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/02/82706180d3d7796633eb558c5239a336ee182d91dbebdcc952e86aa552b8/inspect_swe-0.2.26-py3-none-any.whl", hash = "sha256:44fa73ef08be843b565117f43ee1dd3e737f27a39427d7a4c5d36d244ccb6236", size = 23490, upload-time = "2025-11-15T20:37:23.699Z" },
 ]
 
 [[package]]
@@ -2501,7 +2522,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.8.0"
+version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2513,9 +2534,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/0c/b9321e12f89e236f5e9a46346c30fb801818e22ba33b798a5aca84be895c/openai-2.8.0.tar.gz", hash = "sha256:4851908f6d6fcacbd47ba659c5ac084f7725b752b6bfa1e948b6fbfc111a6bad", size = 602412, upload-time = "2025-11-13T18:15:25.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e4/42591e356f1d53c568418dc7e30dcda7be31dd5a4d570bca22acb0525862/openai-2.8.1.tar.gz", hash = "sha256:cb1b79eef6e809f6da326a7ef6038719e35aa944c42d081807bfa1be8060f15f", size = 602490, upload-time = "2025-11-17T22:39:59.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/e1/0a6560bab7fb7b5a88d35a505b859c6d969cb2fa2681b568eb5d95019dec/openai-2.8.0-py3-none-any.whl", hash = "sha256:ba975e347f6add2fe13529ccb94d54a578280e960765e5224c34b08d7e029ddf", size = 1022692, upload-time = "2025-11-13T18:15:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4f/dbc0c124c40cb390508a82770fb9f6e3ed162560181a85089191a851c59a/openai-2.8.1-py3-none-any.whl", hash = "sha256:c6c3b5a04994734386e8dad3c00a393f56d3b68a27cd2e8acae91a59e4122463", size = 1022688, upload-time = "2025-11-17T22:39:57.675Z" },
 ]
 
 [[package]]
@@ -2523,9 +2544,11 @@ name = "openbench"
 version = "0.5.2"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "datasets" },
     { name = "groq" },
     { name = "inspect-ai" },
+    { name = "inspect-swe" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "numpy" },
@@ -2591,9 +2614,11 @@ tau-bench = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.69.0" },
     { name = "datasets", specifier = ">=3.6.0" },
     { name = "groq", specifier = ">=0.33.0" },
-    { name = "inspect-ai", specifier = "==0.3.125" },
+    { name = "inspect-ai", specifier = "==0.3.141" },
+    { name = "inspect-swe", specifier = ">=0.2.26" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "mcp", specifier = ">=1.13.1" },
     { name = "numpy", specifier = "==2.2.6" },
@@ -2795,6 +2820,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/86/1fa345fc17caf5d7780d2699985c03dbe186c68fee00b526813939062bb0/pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab", size = 11883998, upload-time = "2025-07-07T19:19:34.267Z" },
     { url = "https://files.pythonhosted.org/packages/81/aa/e58541a49b5e6310d89474333e994ee57fea97c8aaa8fc7f00b873059bbf/pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96", size = 12704705, upload-time = "2025-07-07T19:19:36.856Z" },
     { url = "https://files.pythonhosted.org/packages/d5/f9/07086f5b0f2a19872554abeea7658200824f5835c58a106fa8f2ae96a46c/pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444", size = 13189044, upload-time = "2025-07-07T19:19:39.999Z" },
+]
+
+[[package]]
+name = "pathlib-abc"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/cb/448649d7f25d228bf0be3a04590ab7afa77f15e056f8fa976ed05ec9a78f/pathlib_abc-0.5.2.tar.gz", hash = "sha256:fcd56f147234645e2c59c7ae22808b34c364bb231f685ddd9f96885aed78a94c", size = 33342, upload-time = "2025-10-10T18:37:20.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl", hash = "sha256:4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb", size = 19070, upload-time = "2025-10-10T18:37:19.437Z" },
 ]
 
 [[package]]
@@ -4301,6 +4335,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]
+
+[[package]]
+name = "universal-pathlib"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "pathlib-abc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/db/6874223d251a2e146dae57a27ca8cb1f71e7e135aa51ad394173ffe18fc0/universal_pathlib-0.3.6.tar.gz", hash = "sha256:d8640454ff08305fc639f7980e8bad4a7d38e82f6389ff993fb0e7b2a4969de9", size = 249113, upload-time = "2025-11-13T17:05:29.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/5d/fc1f5478eb486a59549e0dbea5827633bbba01139b549968d4936154b756/universal_pathlib-0.3.6-py3-none-any.whl", hash = "sha256:ff10a86e5340ad986b6f04847bb64ba397dff7467450234ffa2ab5ff135641d8", size = 78715, upload-time = "2025-11-13T17:05:28.101Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
- Refactores our dynamic claude agent set up with packaged claude code inspect swe agent
- Adds codex CLI agent and Gemini CLI agent
- Changes default coding agent to codex
- Adds hidden test flag that removes test files from agent workspace to make tasks harder. It better tests models on task ambiguity which is more realistic to real world coding tasks. Quick 30 sample tests shows codex with gpt-5 scores 30% lower with no tests.
- Added test coverage for cli commands and updates documentation
- Ran eval coverage to test inspect ai bump. Results:

Livemcpbench: 0.432 (0.051 stderr)	
Taubench: retail: 0.789, airline: 0.58	
gpqa_diamond: 0.846 (0.021 stderr)	
sealqa: 0.287 (0.028 stderr)	
mrcr: 8n: 0.401, 4n: 0.577, 2n: 0.711	
Humaneval: 0.988 (0.006 stderrr)	
Mathvista 0.715 (0.014 stderr)

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [x] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

<!-- List the main changes in bullet points -->
- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->
- [x] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [x] I have tested with multiple model providers (if applicable)
- [x] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues -->
Closes #

## Additional Context

<!-- Add any other context about the pull request here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Codex (now default), Claude Code, and Gemini agents for Exercism and introduces --hidden-tests with sanitized workspaces, plus docs, deps, and Docker/provider updates.
> 
> - **Exercism benchmark**:
>   - Default `--code-agent` changed from `opencode` to `codex` across tasks and docs.
>   - New `--hidden-tests` flag; tasks propagate `hide_tests` and swap prompt to `EXERCISM_HIDDEN_TEST_PROMPT`.
> - **Agents**:
>   - Add `CodexAgent` (inspect_swe), `ClaudeCodeAgent` (inspect_swe), and `GeminiAgent` CLIs; exported via `openbench.agents` and `AgentManager`.
>   - Enforce model constraints: `roo` requires `openrouter/*`; `claude_code` requires `anthropic/*`.
> - **CLI/Utils**:
>   - `eval` command accepts `--hidden-tests` and forwards `hide_tests` to tasks.
>   - New workspace hiding pipeline: `discover_hidden_paths`, `prepare_hidden_workspace`, `sync_agent_workspace`; rsync-based excludes; Python test filename normalization retained.
> - **Docker/Provider**:
>   - Add `rsync` to base image; add `GeminiCommands`; map agent Docker installs (`claude_code`/`codex` need none).
>   - Google provider includes `GEMINI_API_KEY`.
> - **Dependencies**:
>   - Bump `inspect-ai` to `0.3.141`; add `inspect_swe>=0.2.26` and `anthropic>=0.69.0` in core and root projects.
> - **Config/Metadata**:
>   - Remove `exercism` eval-group from config and snippets (individual tasks remain).
> - **Docs**:
>   - Update Exercism docs/README/release notes for default `codex`, new agents, and `--hidden-tests` usage.
> - **Tests**:
>   - Add `tests/test_exercism_cli.py` covering hidden path discovery, workspace sync, setup/test runners.
>   - Minor updates to Groq provider streaming tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600540ef424d525bf3e9f283da314eb9c8faf90c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->