### PR TITLE
feat: implement model-graded flag for use with MCQEvals

### DIFF
--- a/docs/cli/eval.mdx
+++ b/docs/cli/eval.mdx
@@ -39,6 +39,7 @@ Commonly used configuration options for model selection, evaluation control, per
 | `--fail-on-error` | Failure threshold for sample errors
 | `--timeout` | Request timeout (seconds)
 | `--sandbox` | Container for running generated code
+| `--model-graded` | Use LLM-based answer extraction for [MCQ evals](/development/mcq) (for verbose or complex model responses)
 
 For full collection of eval congifuration parameters, see [Configuration](/configuration).
 

--- a/docs/development/mcq.mdx
+++ b/docs/development/mcq.mdx
@@ -106,3 +106,21 @@ return Task(
     epochs=epochs,
 )
 ```
+
+## Model-Graded Scoring
+
+By default, MCQEval uses regex-based answer extraction that looks for the answer at the beginning of the model response (e.g., `"A"`, `"The answer is B"`, etc.). For custom prompt implementations yielding verbose reasoning or custom response formats, users can opt to enable a more robust LLL-based scoring method.
+
+The `--model-graded` flag enables LLM-based answer extraction using `groq/openai/gpt-oss-20b` as the grading model. This flag should be used as a troubleshooting method when unexpectedly low results are observed with an MCQ benchmark.
+
+### Usage Example
+
+```bash
+# Standard MCQ evaluation (regex-based)
+bench eval mmlu --model openai/gpt-4o
+
+# Model-graded MCQ evaluation (LLM-based)
+bench eval mmlu --model openai/gpt-4o --model-graded
+```
+
+**Note:** Model-graded scoring requires the `GROQ_API_KEY` environment variable to be set. It is slower and more expensive than regex-based scoring, so it should be used when regex extraction proves insufficient.

--- a/src/openbench/utils/mcq.py
+++ b/src/openbench/utils/mcq.py
@@ -11,6 +11,7 @@ from pydantic import BeforeValidator
 from inspect_ai.dataset import Sample, csv_dataset, hf_dataset, json_dataset
 from inspect_ai.solver import generate, system_message
 from inspect_ai import Task, Epochs
+from inspect_ai.scorer import Scorer
 from openbench.scorers.mcq import create_mcq_scorer
 
 
@@ -63,6 +64,186 @@ class MCQSample(Sample):
     target: Annotated[str, BeforeValidator(validate_target)]
 
 
+# ----------- GLOBAL MCQ SCORING CONFIGURATION -----------
+# NOTE: These settings apply to MCQEval infrastructure only.
+# For custom scoring outside MCQEval, use create_mcq_scorer() directly.
+
+USE_MODEL_GRADING = False
+"""
+Global flag to enable model-graded MCQ scoring (default: False).
+
+When False (default), uses regex-based answer extraction (fast, but may have accuracy
+issues with verbose model reasoning).
+
+When True, uses an LLM to grade MCQ answers, which is more reliable for models that
+provide extensive reasoning before their final answer. Enable with --model-graded flag.
+
+This setting applies to all tasks created via MCQEval.
+"""
+
+MCQ_GRADING_MODEL = "groq/openai/gpt-oss-20b"
+"""
+Default model to use for MCQ answer grading (default: "groq/openai/gpt-oss-20b").
+
+This model is used to determine the model's final answer when USE_MODEL_GRADING=True.
+Set to None to use the same model being evaluated.
+"""
+
+
+# ----------- MCQ DETECTION -----------
+
+
+def is_mcq_task(task: Task) -> bool:
+    """Detect if a task uses MCQ scoring by inspecting its scorer.
+
+    This function checks the actual implementation to determine if a task
+    uses MCQEval infrastructure or MCQ-based scorers. It's used both for:
+    1. Runtime validation (--model-graded flag)
+    2. Build-time tagging (auto-generate benchmarks script)
+
+    Args:
+        task: The loaded Inspect AI task object
+
+    Returns:
+        True if the task uses MCQ scoring (either regex or model-graded)
+
+    Examples:
+        >>> from openbench.config import load_task
+        >>> task_fn = load_task("mmlu")
+        >>> task = task_fn()
+        >>> is_mcq_task(task)
+        True
+        >>> task_fn = load_task("humaneval")
+        >>> task = task_fn()
+        >>> is_mcq_task(task)
+        False
+    """
+    # Get the scorer from the task
+    scorer_obj = task.scorer if hasattr(task, "scorer") else None
+    if scorer_obj is None:
+        return False
+
+    # Handle case where scorer is a list (common pattern in Inspect AI)
+    # Extract the first scorer from the list
+    scorer = (
+        scorer_obj[0] if isinstance(scorer_obj, list) and scorer_obj else scorer_obj
+    )
+    if scorer is None or (isinstance(scorer_obj, list) and not scorer_obj):
+        return False
+
+    # Check if it's a Scorer instance
+    if isinstance(scorer, Scorer):
+        # Check the scorer's name - MCQ scorers have specific naming patterns
+        scorer_name = scorer.name if hasattr(scorer, "name") else ""
+
+        # Scorers from create_mcq_scorer are named "mcq_scorer"
+        # model_graded_fact scorers are named "model_graded_fact"
+        if scorer_name in ["mcq_scorer", "model_graded_fact"]:
+            return True
+
+        # Also check if the scorer function name contains mcq-related terms
+        # This handles pre-configured scorers like mmlu_simple_eval_scorer, tumlu_simple_eval_scorer
+        if hasattr(scorer, "_scorer") and hasattr(scorer._scorer, "__name__"):
+            func_name = scorer._scorer.__name__.lower()
+            if "mcq" in func_name:
+                return True
+
+    # Check if it's a callable (scorer function directly)
+    if callable(scorer):
+        # Check function name for mcq-related terms
+        func_name = getattr(scorer, "__name__", "").lower()
+        if "mcq" in func_name or "score" in func_name:
+            # Additional check: look for create_mcq_scorer in the qualified name
+            qual_name = getattr(scorer, "__qualname__", "")
+            if "mcq_scorer" in qual_name or "create_mcq_scorer" in qual_name:
+                return True
+
+    return False
+
+
+def get_mcq_benchmarks(include_alpha: bool = False) -> List[str]:
+    """Get a list of all MCQ benchmarks by static analysis of eval files.
+
+    This function uses grep to search for MCQ-related patterns in eval files,
+    which is much faster than loading all benchmarks.
+
+    Detects MCQ benchmarks by searching for:
+    - MCQEval( - tasks using the MCQEval factory
+    - create_mcq_scorer - tasks using MCQ scorers directly
+
+    Used by:
+    1. CLI validation for --model-graded flag
+    2. Auto-generate script for adding "mcq" tags
+
+    Args:
+        include_alpha: Whether to include alpha/experimental benchmarks
+
+    Returns:
+        List of benchmark names that use MCQ scoring
+
+    Note:
+        This uses static analysis (grep) which is very fast (~1 second)
+        instead of loading all benchmarks (~3 minutes).
+    """
+    import subprocess
+    from pathlib import Path
+
+    # Avoid circular import
+    from openbench.config import get_all_benchmarks
+
+    # Get the evals directory
+    evals_dir = Path(__file__).parent.parent / "evals"
+
+    # Search for MCQ patterns in eval files
+    mcq_files = set()
+
+    try:
+        # Search for MCQEval usage
+        result = subprocess.run(
+            ["grep", "-l", "-r", "MCQEval(", str(evals_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            mcq_files.update(result.stdout.strip().split("\n"))
+    except Exception:
+        pass
+
+    try:
+        # Search for create_mcq_scorer usage
+        result = subprocess.run(
+            ["grep", "-l", "-r", "create_mcq_scorer", str(evals_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            mcq_files.update(result.stdout.strip().split("\n"))
+    except Exception:
+        pass
+
+    # Get all benchmarks and their file paths
+    all_benchmarks = get_all_benchmarks(include_alpha=include_alpha)
+
+    # Map eval files to benchmark names
+    mcq_benchmarks = []
+    for benchmark_name, metadata in all_benchmarks.items():
+        # Extract eval filename from module_path (e.g., "openbench.evals.mmlu" -> "mmlu.py")
+        if hasattr(metadata, "module_path"):
+            # Split module path and get the filename part
+            parts = metadata.module_path.split(".")
+            if len(parts) >= 3 and parts[0] == "openbench" and parts[1] == "evals":
+                eval_filename = parts[2] + ".py"
+                # Check if this file uses MCQ patterns
+                if any(
+                    str(f).endswith(f"/{eval_filename}")
+                    or str(f).endswith(f"\\{eval_filename}")
+                    for f in mcq_files
+                ):
+                    mcq_benchmarks.append(benchmark_name)
+
+    return mcq_benchmarks
+
+
 # ----------- TASK FACTORY -----------
 def MCQEval(
     *,
@@ -82,6 +263,10 @@ def MCQEval(
 ) -> "Task":
     """
     Build a Task using a user-provided record_to_mcq_sample().
+
+    Scoring behavior is controlled by global configuration:
+    - `USE_MODEL_GRADING`: Enable model-graded scoring (default: True)
+    - `MCQ_GRADING_MODEL`: Model to use for grading (default: "groq/openai/gpt-oss-20b")
 
     Args:
         name: Task name.
@@ -133,9 +318,12 @@ def MCQEval(
     if prompt_template:
         solver = [system_message(prompt_template), generate()]
 
+    # Use global MCQ scoring configuration
     scorer = create_mcq_scorer(
         group_keys=group_keys,
         additional_metrics=additional_metrics,
+        use_model_grading=USE_MODEL_GRADING,
+        grading_model=MCQ_GRADING_MODEL,
     )()
 
     return Task(


### PR DESCRIPTION
## Summary

Implements a global CLI flag (--model-graded) that enables a LLM-as-a-judge implementation of the specified benchmark. Only to be used with MCQEval tasks, validated by searching for "mcq" in task metadata tags (note: bind between MCQEval implementation and "mcq" tag in metadata is enforced by CI workflow in separate PR, see it here).

## What are you adding?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [X] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Testing

- [X] I have run the existing test suite (`pytest`)
- [X] Tested locally with MCQEval and non-MCQEval for proper functionality
- [X] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a --model-graded flag to enable LLM-based MCQ grading, validates usage for MCQ benchmarks, wires global scoring config, updates MCQ scorer, and documents usage.
> 
> - **CLI**:
>   - Add `--model-graded` flag in `src/openbench/_cli/eval_command.py` with help/env var; expand groups early and validate via `validate_mcq_flag()`.
>   - On enable, set `openbench.utils.mcq.USE_MODEL_GRADING=True`, echo notice, and warn if `GROQ_API_KEY` missing.
> - **Scoring (MCQ)**:
>   - Enhance `create_mcq_scorer()` in `src/openbench/scorers/mcq.py` to support LLM grading via `model_graded_fact` with custom instructions and optional `grading_model`.
>   - Default remains regex-based; returns model-graded scorer when enabled.
> - **Utils/Infrastructure**:
>   - Add global config `USE_MODEL_GRADING` and `MCQ_GRADING_MODEL`; have `MCQEval()` pass these into `create_mcq_scorer()`.
>   - Add MCQ detection helpers `is_mcq_task()` and fast static analysis `get_mcq_benchmarks()` in `src/openbench/utils/mcq.py`.
>   - Add `validate_mcq_flag()` in CLI to restrict flag to MCQ benchmarks.
> - **Docs**:
>   - Document `--model-graded` in `docs/cli/eval.mdx`.
>   - Add "Model-Graded Scoring" section with usage and notes in `docs/development/mcq.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bc56aa7df05a7e0df2f0ef67fd9dad167fd7bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->