### PR TITLE
feat: add chat-completions/ and responses/ provider prefixes

### DIFF
--- a/docs/providers.mdx
+++ b/docs/providers.mdx
@@ -43,9 +43,9 @@ To access any major model, set the appropriate API key environment variable:
 
 ## Using Unsupported Providers
 
-openbench works with any OpenAI-compatible API endpoint, even if the provider isn't listed above. This allows you to benchmark models from new or specialized providers that support the OpenAI Chat Completions API format.
+openbench works with any OpenAI-compatible API endpoint, even if the provider isn't listed above. This allows you to benchmark models from new or specialized providers that support the OpenAI Chat Completions or Responses API format.
 
-1. Use the model string format: `openai-api/<provider>/<model-name>`
+1. Use the model string format: `chat-completions/<provider>/<model-name>` or `responses/<provider>/<model-name>`
 2. Set environment variables: `<PROVIDER>_API_KEY` and `<PROVIDER>_BASE_URL`
 
 ```bash
@@ -53,7 +53,7 @@ openbench works with any OpenAI-compatible API endpoint, even if the provider is
 export GROQ_API_KEY="gsk_..."
 export GROQ_BASE_URL=https://api.groq.com/openai/v1
 
-bench eval mmlu --model openai-api/groq/openai/gpt-oss-120b
+bench eval mmlu --model chat-completions/groq/openai/gpt-oss-120b
 ```
 
 ## General Model Configuration

--- a/packages/openbench-core/pyproject.toml
+++ b/packages/openbench-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openbench-core"
-version = "0.5.2"
+version = "0.5.3"
 requires-python = ">=3.10"
 description = "openbench - open source, replicable, and standardized evaluation infrastructure"
 license = {text = "MIT"}

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -195,6 +195,22 @@ def siliconflow() -> Type[ModelAPI]:
     return SiliconFlowAPI
 
 
+@modelapi(name="responses")
+def responses() -> Type[ModelAPI]:
+    """Register generic responses/ format provider."""
+    from .model._providers.responses import ResponsesFormatAPI
+
+    return ResponsesFormatAPI
+
+
+@modelapi(name="chat-completions")
+def chat_completions() -> Type[ModelAPI]:
+    """Register generic chat-completions/ format provider."""
+    from .model._providers.chat_completions import ChatCompletionsFormatAPI
+
+    return ChatCompletionsFormatAPI
+
+
 def _override_builtin_groq_provider():
     """Replace Inspect AI's built-in groq provider with enhanced openbench version."""
     from inspect_ai._util.registry import _registry

--- a/src/openbench/model/_providers/chat_completions.py
+++ b/src/openbench/model/_providers/chat_completions.py
@@ -1,0 +1,197 @@
+"""
+Generic chat completions format provider for Chat Completions API.
+"""
+
+import os
+from typing import Any, cast
+
+from openai import AsyncOpenAI
+from openai._types import NOT_GIVEN
+from openai.types.chat import ChatCompletion
+from typing_extensions import override
+
+from inspect_ai.model._chat_message import ChatMessage
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model import ModelAPI
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._openai import (
+    OpenAIAsyncHttpxClient,
+    chat_choices_from_openai,
+    messages_to_openai,
+    model_output_from_openai,
+    openai_chat_tool_choice,
+    openai_chat_tools,
+    openai_completion_params,
+    openai_media_filter,
+    openai_should_retry,
+)
+from inspect_ai.model._providers.util.hooks import HttpxHooks
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+
+class ChatCompletionsFormatAPI(ModelAPI):
+    """
+    Provider for Chat Completions API format.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        """
+        Initialize chat completions format provider.
+
+        Args:
+            model_name: Full model string (format: chat-completions/provider/model)
+            config: Generation configuration
+            **model_args: Additional model arguments
+        """
+        # Clean format prefix from model name
+        model_name_clean = model_name.replace("chat-completions/", "", 1)
+
+        # Extract provider name from model string (pattern: provider/model)
+        parts = model_name_clean.split("/")
+        if len(parts) == 1:
+            raise ValueError(
+                "chat-completions model names must include a provider prefix "
+                "(e.g. 'chat-completions/provider/model'). "
+                "The provider name is used to lookup environment variables PROVIDER_API_KEY and and PROVIDER_BASE_URL."
+            )
+
+        self.provider = parts[0]
+        self.actual_model_name = "/".join(parts[1:])  # Handle nested slashes
+
+        # Compute environment variable names from provider
+        provider_env_name = self.provider.upper().replace("-", "_")
+        api_key_var = f"{provider_env_name}_API_KEY"
+        base_url_var = f"{provider_env_name}_BASE_URL"
+
+        # Get API key and base URL from environment variables
+        api_key = os.environ.get(api_key_var)
+
+        base_url = os.environ.get(base_url_var)
+        if not base_url:
+            raise ValueError(
+                f"Base URL is required. Set {base_url_var} environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            api_key_vars=[api_key_var],
+            config=config,
+        )
+
+        # Create OpenAI client
+        http_client = model_args.pop("http_client", OpenAIAsyncHttpxClient())
+        # Remove base_url and api_key from model_args to avoid conflicts
+        model_args.pop("base_url", None)
+        model_args.pop("api_key", None)
+        self.client = AsyncOpenAI(
+            api_key=self.api_key or "dummy",  # OpenAI client requires a key
+            base_url=self.base_url,
+            http_client=http_client,
+            **model_args,
+        )
+
+        # Create time tracker
+        self._http_hooks = HttpxHooks(self.client._client)
+
+    @override
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> tuple[ModelOutput | Exception, ModelCall]:
+        """
+        Generate a response using the Chat Completions API.
+
+        Args:
+            input: Chat messages
+            tools: Available tools
+            tool_choice: Tool selection preference
+            config: Generation configuration
+
+        Returns:
+            Tuple of (ModelOutput or Exception, ModelCall)
+        """
+        # Allocate request ID
+        request_id = self._http_hooks.start_request()
+
+        # Setup request and response for ModelCall
+        request: dict[str, Any] = {}
+        response: dict[str, Any] = {}
+
+        def model_call() -> ModelCall:
+            return ModelCall.create(
+                request=request,
+                response=response,
+                filter=openai_media_filter,
+                time=self._http_hooks.end_request(request_id),
+            )
+
+        try:
+            # Get completion params
+            completion_params = openai_completion_params(
+                model=self.actual_model_name,
+                config=config,
+                tools=len(tools) > 0,
+            )
+
+            # Prepare request
+            have_tools = len(tools) > 0
+            request = dict(
+                messages=await messages_to_openai(input),
+                tools=openai_chat_tools(tools) if have_tools else NOT_GIVEN,
+                tool_choice=openai_chat_tool_choice(tool_choice)
+                if have_tools
+                else NOT_GIVEN,
+                extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
+                **completion_params,
+            )
+
+            # Generate completion using OpenAI SDK
+            completion = cast(
+                ChatCompletion, await self.client.chat.completions.create(**request)
+            )
+            response = completion.model_dump()
+
+            # Parse choices
+            choices = chat_choices_from_openai(completion, tools)
+
+            # Return output
+            return model_output_from_openai(completion, choices), model_call()
+
+        except Exception as ex:
+            return ex, model_call()
+
+    @override
+    def should_retry(self, ex: Exception) -> bool:
+        """Determine if a request should be retried."""
+        return openai_should_retry(ex)
+
+    @override
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self.client.close()
+
+    @override
+    def connection_key(self) -> str:
+        """Get the connection key for connection pooling."""
+        return str(self.api_key or self.base_url)
+
+    @override
+    def collapse_user_messages(self) -> bool:
+        """Whether to collapse consecutive user messages."""
+        return False
+
+    @override
+    def collapse_assistant_messages(self) -> bool:
+        """Whether to collapse consecutive assistant messages."""
+        return False

--- a/src/openbench/model/_providers/responses.py
+++ b/src/openbench/model/_providers/responses.py
@@ -189,8 +189,8 @@ class ResponsesFormatAPI(ModelAPI):
                                 texts.append(c.get("text", ""))  # type: ignore[misc]
                         extracted_text = "\n".join(texts) if texts else None
 
-                        # Only treat as instructions if we successfully extracted text
-                        if extracted_text:
+                        # Only treat as instructions if we successfully extracted non-whitespace text
+                        if extracted_text and extracted_text.strip():
                             instructions = extracted_text
                         else:
                             # No text content found, preserve the message

--- a/src/openbench/model/_providers/responses.py
+++ b/src/openbench/model/_providers/responses.py
@@ -166,7 +166,7 @@ class ResponsesFormatAPI(ModelAPI):
         try:
             # Convert messages to responses input format
             openai_api_adapter = _OpenAIAPIAdapter(self.actual_model_name)
-            input_items = await openai_responses_inputs(input, openai_api_adapter)  # type: ignore[arg-type]
+            input_items = await openai_responses_inputs(input, openai_api_adapter)  # type: ignore[arg-type,call-arg]
 
             # Extract instructions from first system message
             instructions: str | None = None

--- a/src/openbench/model/_providers/responses.py
+++ b/src/openbench/model/_providers/responses.py
@@ -1,0 +1,324 @@
+"""
+Generic responses format provider for Responses API.
+"""
+
+import logging
+import os
+from typing import Any, cast
+
+from openai import AsyncOpenAI, BadRequestError
+from openai._types import NOT_GIVEN
+from openai.types.responses import Response as OpenAIResponse
+from typing_extensions import override
+
+from inspect_ai.model._chat_message import ChatMessage
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model import ModelAPI
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.model._openai import (
+    OpenAIAsyncHttpxClient,
+    openai_media_filter,
+    openai_should_retry,
+)
+from inspect_ai.model._openai_responses import (
+    openai_responses_chat_choices,
+    openai_responses_inputs,
+    openai_responses_tool_choice,
+    openai_responses_tools,
+)
+from inspect_ai.model._providers.util.hooks import HttpxHooks
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+# Set up logger for this module
+logger = logging.getLogger(__name__)
+
+
+class _OpenAIAPIAdapter:
+    """
+    Minimal adapter to enable Inspect AI responses utilities for generic providers.
+
+    The openai_responses_inputs() function requires an OpenAIAPI instance to check
+    model type (o-series vs gpt-5) to determine whether to use "developer" or "system"
+    role for system messages. For generic providers, we conservatively use "system" role.
+    """
+
+    def __init__(self, model_name: str):
+        """Initialize adapter with model name."""
+        self.model_name = model_name
+
+    def is_o_series(self) -> bool:
+        """Check if model is o-series. Generic providers: return False."""
+        return False
+
+    def is_gpt_5(self) -> bool:
+        """Check if model is gpt-5. Generic providers: return False."""
+        return False
+
+
+class ResponsesFormatAPI(ModelAPI):
+    """
+    Provider for Responses API format.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        """
+        Initialize responses format provider.
+
+        Args:
+            model_name: Full model string (format: responses/provider/model)
+            config: Generation configuration
+            **model_args: Additional model arguments
+        """
+        # Clean format prefix from model name
+        model_name_clean = model_name.replace("responses/", "", 1)
+
+        # Extract provider name from model string (pattern: provider/model)
+        parts = model_name_clean.split("/")
+        if len(parts) == 1:
+            raise ValueError(
+                "responses model names must include a provider prefix "
+                "(e.g. 'responses/provider/model'). "
+                "The provider name is used to lookup environment variables PROVIDER_API_KEY and PROVIDER_BASE_URL."
+            )
+
+        self.provider = parts[0]
+        self.actual_model_name = "/".join(parts[1:])  # Handle nested slashes
+
+        # Compute environment variable names from provider
+        provider_env_name = self.provider.upper().replace("-", "_")
+        api_key_var = f"{provider_env_name}_API_KEY"
+        base_url_var = f"{provider_env_name}_BASE_URL"
+
+        # Get API key and base URL from environment variables
+        api_key = os.environ.get(api_key_var)
+
+        base_url = os.environ.get(base_url_var)
+        if not base_url:
+            raise ValueError(
+                f"Base URL is required. Set {base_url_var} environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            api_key_vars=[api_key_var],
+            config=config,
+        )
+
+        # Create OpenAI client
+        http_client = model_args.pop("http_client", OpenAIAsyncHttpxClient())
+        # Remove base_url and api_key from model_args to avoid conflicts
+        model_args.pop("base_url", None)
+        model_args.pop("api_key", None)
+
+        self.client = AsyncOpenAI(
+            api_key=self.api_key or "dummy",  # OpenAI client requires a key
+            base_url=self.base_url,
+            http_client=http_client,
+            **model_args,
+        )
+
+        # Create time tracker
+        self._http_hooks = HttpxHooks(self.client._client)
+
+    @override
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> tuple[ModelOutput | Exception, ModelCall]:
+        """
+        Generate a response using the OpenAI Responses API.
+
+        Args:
+            input: Chat messages
+            tools: Available tools
+            tool_choice: Tool selection preference
+            config: Generation configuration
+
+        Returns:
+            Tuple of (ModelOutput or Exception, ModelCall)
+        """
+        # Allocate request ID
+        request_id = self._http_hooks.start_request()
+
+        # Setup request and response for ModelCall
+        request_dict: dict[str, Any] = {}
+        response_dict: dict[str, Any] = {}
+
+        def model_call() -> ModelCall:
+            return ModelCall.create(
+                request=request_dict,
+                response=response_dict,
+                filter=openai_media_filter,
+                time=self._http_hooks.end_request(request_id),
+            )
+
+        try:
+            # Convert messages to responses input format
+            openai_api_adapter = _OpenAIAPIAdapter(self.actual_model_name)
+            input_items = await openai_responses_inputs(input, openai_api_adapter)  # type: ignore[arg-type]
+
+            # Extract instructions from first system message
+            instructions: str | None = None
+            filtered_items: list[Any] = []
+            for item in input_items:
+                # Check if this is a message item with system role
+                if (
+                    isinstance(item, dict)
+                    and item.get("type") == "message"  # type: ignore[misc]
+                    and item.get("role") == "system"  # type: ignore[misc]
+                    and instructions is None
+                ):
+                    # Extract content as instructions
+                    content: Any = item.get("content", [])  # type: ignore[misc]
+                    if content:
+                        # Join text content from content array
+                        texts = []
+                        for c in content:
+                            if isinstance(c, dict) and c.get("type") == "text":  # type: ignore[misc]
+                                texts.append(c.get("text", ""))  # type: ignore[misc]
+                        instructions = "\n".join(texts) if texts else None
+                else:
+                    filtered_items.append(item)
+
+            # Build completion params
+            params: dict[str, Any] = {
+                "model": self.actual_model_name,
+            }
+
+            # Add supported config parameters
+            # Responses API uses max_output_tokens (not max_tokens)
+            if config.max_tokens is not None:
+                params["max_output_tokens"] = config.max_tokens
+            if config.temperature is not None:
+                params["temperature"] = config.temperature
+            if config.top_p is not None:
+                params["top_p"] = config.top_p
+
+            # Unsupported params are silently ignored
+
+            # Convert tools to responses format
+            have_tools = len(tools) > 0
+            if have_tools:
+                tool_params: Any = openai_responses_tools(
+                    tools, self.actual_model_name, config
+                )
+                tool_choice_param: Any = openai_responses_tool_choice(
+                    tool_choice, tool_params
+                )
+            else:
+                tool_params = NOT_GIVEN
+                tool_choice_param = NOT_GIVEN
+
+            # Prepare request
+            request_dict = {
+                "input": filtered_items,
+                "instructions": instructions if instructions else NOT_GIVEN,
+                "tools": tool_params,
+                "tool_choice": tool_choice_param,
+                "extra_headers": {HttpxHooks.REQUEST_ID_HEADER: request_id},
+                **params,
+            }
+
+            # Generate response using OpenAI SDK
+            try:
+                openai_response = cast(
+                    OpenAIResponse,
+                    await self.client.responses.create(**request_dict),  # type: ignore[arg-type]
+                )
+            except BadRequestError as e:
+                # Check if this is an unsupported parameter error
+                error_message = str(e)
+                if (
+                    "Unsupported parameter" in error_message
+                    or "not supported" in error_message
+                ):
+                    # Retry without optional parameters
+                    logger.warning(
+                        f"Model {self.actual_model_name} does not support some parameters. "
+                        f"Attempting to continue with the model's default values. "
+                        f"Original error: {error_message}"
+                    )
+
+                    # Build minimal request without optional params
+                    minimal_params = {"model": self.actual_model_name}
+                    minimal_request_dict: dict[str, Any] = {
+                        "input": filtered_items,
+                        "instructions": instructions if instructions else NOT_GIVEN,
+                        "tools": tool_params,
+                        "tool_choice": tool_choice_param,
+                        "extra_headers": {HttpxHooks.REQUEST_ID_HEADER: request_id},
+                        **minimal_params,
+                    }
+
+                    # Retry with minimal params
+                    openai_response = cast(
+                        OpenAIResponse,
+                        await self.client.responses.create(**minimal_request_dict),  # type: ignore[arg-type]
+                    )
+                else:
+                    # Not an unsupported parameter error, re-raise
+                    raise
+
+            response_dict = openai_response.model_dump()
+
+            # Parse choices using Inspect AI utility
+            choices = openai_responses_chat_choices(
+                self.actual_model_name,
+                openai_response,
+                tools,
+            )
+
+            # Extract usage if available
+            usage = None
+            if openai_response.usage:
+                usage = ModelUsage(
+                    input_tokens=openai_response.usage.input_tokens,
+                    output_tokens=openai_response.usage.output_tokens,
+                    total_tokens=openai_response.usage.total_tokens,
+                )
+
+            # Build ModelOutput
+            return ModelOutput(
+                model=openai_response.model,
+                choices=choices,
+                usage=usage,
+            ), model_call()
+
+        except Exception as ex:
+            return ex, model_call()
+
+    @override
+    def should_retry(self, ex: Exception) -> bool:
+        """Determine if a request should be retried."""
+        return openai_should_retry(ex)
+
+    @override
+    async def aclose(self) -> None:
+        """Close the HTTP client."""
+        await self.client.close()
+
+    @override
+    def connection_key(self) -> str:
+        """Get the connection key for connection pooling."""
+        return str(self.api_key or self.base_url)
+
+    @override
+    def collapse_user_messages(self) -> bool:
+        """Whether to collapse consecutive user messages."""
+        return False
+
+    @override
+    def collapse_assistant_messages(self) -> bool:
+        """Whether to collapse consecutive assistant messages."""
+        return False

--- a/src/openbench/model/_providers/responses.py
+++ b/src/openbench/model/_providers/responses.py
@@ -276,6 +276,9 @@ class ResponsesFormatAPI(ModelAPI):
                         OpenAIResponse,
                         await self.client.responses.create(**minimal_request_dict),  # type: ignore[arg-type]
                     )
+
+                    # Update request_dict to reflect the actual request sent
+                    request_dict = minimal_request_dict
                 else:
                     # Not an unsupported parameter error, re-raise
                     raise

--- a/src/openbench/model/_providers/responses.py
+++ b/src/openbench/model/_providers/responses.py
@@ -187,7 +187,17 @@ class ResponsesFormatAPI(ModelAPI):
                         for c in content:
                             if isinstance(c, dict) and c.get("type") == "text":  # type: ignore[misc]
                                 texts.append(c.get("text", ""))  # type: ignore[misc]
-                        instructions = "\n".join(texts) if texts else None
+                        extracted_text = "\n".join(texts) if texts else None
+
+                        # Only treat as instructions if we successfully extracted text
+                        if extracted_text:
+                            instructions = extracted_text
+                        else:
+                            # No text content found, preserve the message
+                            filtered_items.append(item)
+                    else:
+                        # Empty content, preserve the message
+                        filtered_items.append(item)
                 else:
                     filtered_items.append(item)
 

--- a/src/openbench/provider_config.py
+++ b/src/openbench/provider_config.py
@@ -19,6 +19,7 @@ class ProviderType(str, Enum):
     AZURE = "azure"
     BASETEN = "baseten"
     CEREBRAS = "cerebras"
+    CHAT_COMPLETIONS = "chat-completions"
     COHERE = "cohere"
     CRUSOE = "crusoe"
     DEEPINFRA = "deepinfra"
@@ -42,6 +43,7 @@ class ProviderType(str, Enum):
     PARASAIL = "parasail"
     PERPLEXITY = "perplexity"
     REKA = "reka"
+    RESPONSES = "responses"
     SAMBANOVA = "sambanova"
     SILICONFLOW = "siliconflow"
     TOGETHER = "together"
@@ -133,6 +135,15 @@ PROVIDER_CONFIGS: Dict[ProviderType, ProviderConfig] = {
         base_url="https://api.cerebras.ai/v1",
         supports_vision=False,
         supports_function_calling=True,
+    ),
+    ProviderType.CHAT_COMPLETIONS: ProviderConfig(
+        name="chat-completions",
+        display_name="Generic Chat Completions Format",
+        api_key_env="CHAT_COMPLETIONS_API_KEY",
+        base_url_env="CHAT_COMPLETIONS_BASE_URL",
+        supports_vision=False,
+        supports_function_calling=True,
+        requires_auth=False,
     ),
     ProviderType.COHERE: ProviderConfig(
         name="cohere",
@@ -326,6 +337,15 @@ PROVIDER_CONFIGS: Dict[ProviderType, ProviderConfig] = {
         base_url_env="REKA_BASE_URL",
         supports_vision=True,
         supports_function_calling=True,
+    ),
+    ProviderType.RESPONSES: ProviderConfig(
+        name="responses",
+        display_name="Generic Responses Format",
+        api_key_env="RESPONSES_API_KEY",
+        base_url_env="RESPONSES_BASE_URL",
+        supports_vision=False,
+        supports_function_calling=False,
+        requires_auth=False,
     ),
     ProviderType.SAMBANOVA: ProviderConfig(
         name="sambanova",


### PR DESCRIPTION
## Summary

Adds `chat-completions/` and `responses/` prefixes, providing a universal entrypoint for LLM APIs that support Chat Completions or Responses. This allows openbench to support LLM providers that have not been explictly implemented in openbench. Users add a base URL, API key, and prefix their model ID with `chat-completions/` or `responses/`. This is similar to Inspect AI's `openai-api/` prefix.

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New benchmark/evaluation
- [x] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [x] Documentation update
- [x] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

<!-- List the main changes in bullet points -->
- chat_completions.py, which is a generic format provider for Chat Completions API endpoint
- responses.py, which is a generic format provider for Responses API endpoint
- Relevant updates to the registry, provider config, and docs

## Testing

<!-- Describe how you tested your changes -->
- [x] I have run the existing test suite (`pytest`)
- [ ] I have added tests for my changes
- [x] I have tested with multiple model providers (if applicable)
- [x] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues -->
Closes #

## Additional Context

<!-- Add any other context about the pull request here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces generic Chat Completions and Responses format providers with new `chat-completions/<provider>/<model>` and `responses/<provider>/<model>` prefixes, updates registry/docs/config, and bumps core to 0.5.3.
> 
> - **Providers**:
>   - Add `ChatCompletionsFormatAPI` (`src/openbench/model/_providers/chat_completions.py`) and `ResponsesFormatAPI` (`src/openbench/model/_providers/responses.py`).
>   - Register new prefixes in `_registry.py` as `chat-completions` and `responses`.
>   - Extend `ProviderType` and `PROVIDER_CONFIGS` with generic entries (env vars `CHAT_COMPLETIONS_BASE_URL`, `RESPONSES_BASE_URL`, etc.).
> - **Docs**:
>   - Update unsupported providers guidance to use `chat-completions/<provider>/<model-name>` or `responses/<provider>/<model-name>` and adjust example command.
> - **Version**:
>   - Bump `openbench-core` version to `0.5.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eb0705d61d51078c7aa214783d76b8fd0bd33f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->