### PR TITLE
Adding terraform generation to openbench.

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -482,5 +482,8 @@ from .evals.legalsupport import legalsupport  # noqa: F401, E402
 # spatial reasoning benchmarks
 from .evals.rocketscience import rocketscience  # noqa: F401, E402
 
+# Terraform generation (prompt → Terraform, scored by init + validate)
+from .evals.terraform_generation import terraform_generation  # noqa: F401, E402
+
 # Vision & OCR benchmarks
 from .evals.ocrbenchv2 import ocrbenchv2  # noqa: F401, E402

--- a/src/openbench/config.py
+++ b/src/openbench/config.py
@@ -2871,6 +2871,14 @@ _BUILTIN_BENCHMARKS = {
         module_path="openbench.evals.rootly_terraform",
         function_name="rootly_terraform",
     ),
+    "terraform_generation": BenchmarkMetadata(
+        name="Terraform Generation",
+        description="Generate Terraform (HCL) code from natural-language prompts; scored by terraform init + validate.",
+        category="community",
+        tags=["terraform", "code-generation", "sre", "infrastructure"],
+        module_path="openbench.evals.terraform_generation",
+        function_name="terraform_generation",
+    ),
     "jsonschemabench": BenchmarkMetadata(
         name="JSONSchemaBench",
         description="JSON Schema generation benchmark with ~10K real-world schemas from GitHub, Kubernetes, and other sources for evaluating constrained decoding",

--- a/src/openbench/datasets/terraform_generation.py
+++ b/src/openbench/datasets/terraform_generation.py
@@ -1,0 +1,90 @@
+"""
+Terraform generation prompts: natural-language prompts that ask the model to produce
+executable Terraform (HCL) code. Used by the terraform_generation eval.
+
+Run: bench eval terraform_generation --model "groq/llama-3.1-8b-instant"
+"""
+
+from inspect_ai.dataset import MemoryDataset, Sample
+
+# Bundled prompts (one sample per task). Can be extended via HuggingFace or file later.
+TERRAFORM_PROMPTS = [
+    {
+        "task_id": "task_vpc_3subnets_3ec2",
+        "input": """You are generating Terraform code. Create EXACTLY three files: main.tf, variables.tf, outputs.tf.
+
+Requirements:
+- Terraform >= 1.5
+- Provider: hashicorp/aws
+- Must work with LocalStack at http://localhost:4566
+  Configure provider endpoints for ec2, iam, sts to http://localhost:4566 and set:
+  skip_credentials_validation=true
+  skip_metadata_api_check=true
+  skip_requesting_account_id=true
+  s3_use_path_style=true
+- Variables (ALL must have default values to avoid interactive prompts):
+  region (string, default = "us-east-1")
+  vpc_cidr (string)
+  subnet_cidrs (list(string)) length 3
+  instance_type (string)
+- Create:
+  1 VPC (CIDR = var.vpc_cidr)
+  3 Subnets (CIDRs = var.subnet_cidrs) in that VPC
+  3 EC2 instances, one in each subnet
+- Tag all resources:
+  project = "sre-skills-bench"
+  task_id = "task_vpc_3subnets_3ec2"
+- Outputs:
+  vpc_id
+  subnet_ids (list)
+  instance_ids (list)
+
+Return ONLY code blocks, one per file, labeled with the filename.""",
+    },
+    {
+        "task_id": "task_s3_bucket_policy",
+        "input": """You are generating Terraform code. Create EXACTLY three files: main.tf, variables.tf, outputs.tf.
+
+Requirements:
+- Terraform >= 1.5
+- Provider: hashicorp/aws
+- Must work with LocalStack at http://localhost:4566
+  Configure provider endpoints for s3, iam, sts to http://localhost:4566 and set:
+  skip_credentials_validation=true
+  skip_metadata_api_check=true
+  skip_requesting_account_id=true
+  s3_use_path_style=true
+- Variables (ALL must have default values to avoid interactive prompts):
+  region (string, default = "us-east-1")
+  bucket_name (string)
+  allowed_principal_arn (string)
+- Create:
+  1 S3 bucket with name = var.bucket_name
+  1 S3 bucket policy that allows:
+    - s3:GetObject for the specified principal (var.allowed_principal_arn)
+    - s3:ListBucket for the specified principal
+    Use aws_s3_bucket_policy resource to attach the policy
+    The policy document should be in JSON format
+- Tag all resources:
+  project = "sre-skills-bench"
+  task_id = "task_s3_bucket_policy"
+- Outputs:
+  bucket_id
+  bucket_arn
+
+Return ONLY code blocks, one per file, labeled with the filename.""",
+    },
+]
+
+
+def load_dataset() -> MemoryDataset:
+    """Load Terraform generation dataset (prompts as inputs, target = pass after validate)."""
+    samples = [
+        Sample(
+            input=p["input"],
+            target="pass",
+            metadata={"task_id": p["task_id"]},
+        )
+        for p in TERRAFORM_PROMPTS
+    ]
+    return MemoryDataset(samples=samples, name="terraform_generation")

--- a/src/openbench/evals/terraform_generation.py
+++ b/src/openbench/evals/terraform_generation.py
@@ -1,0 +1,27 @@
+"""
+Terraform Generation benchmark: prompt → Terraform code, scored by init + validate.
+
+Authored for: sre-skills-bench / openbench
+Based on: https://github.com/groq/openbench (same pattern as rootly_gmcq, PR #114)
+
+Run:
+  bench eval terraform_generation --model "groq/llama-3.1-8b-instant"
+
+Requires: terraform CLI on PATH. No LocalStack required for this eval (validate only).
+"""
+
+from inspect_ai import Task, task
+from inspect_ai.solver import generate
+
+from openbench.datasets.terraform_generation import load_dataset
+from openbench.scorers.terraform_generation import terraform_generation_scorer
+
+
+@task
+def terraform_generation() -> Task:
+    """Terraform Generation: generate Terraform from prompts, score by init + validate."""
+    return Task(
+        dataset=load_dataset(),
+        solver=[generate()],
+        scorer=terraform_generation_scorer(),
+    )

--- a/src/openbench/scorers/terraform_generation.py
+++ b/src/openbench/scorers/terraform_generation.py
@@ -1,0 +1,128 @@
+"""
+Scorer for Terraform generation: extract .tf code from model output, run terraform init + validate.
+Pass = 1.0 if init and validate succeed; 0.0 otherwise. No LocalStack required.
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+from inspect_ai.scorer import Score, Target, accuracy, stderr, scorer
+from inspect_ai.solver import TaskState
+
+
+def _extract_tf_blocks(text: str) -> dict[str, str]:
+    """Extract Terraform code blocks from model output (```filename.tf or ```terraform)."""
+    files: dict[str, str] = {}
+    # ```main.tf\n...\n``` or ```terraform\n...\n``` - capture optional name and content
+    pattern = r"```(\w+\.tf|terraform|hcl)?\s*\n(.*?)```"
+    for m in re.finditer(pattern, text, re.DOTALL | re.IGNORECASE):
+        raw_name = (m.group(1) or "").strip().lower()
+        block = (m.group(2) or "").strip()
+        if not block or len(block) < 20:
+            continue
+        if raw_name and raw_name.endswith(".tf"):
+            name = raw_name
+        elif raw_name in ("terraform", "hcl") and "main.tf" not in files:
+            name = "main.tf"
+        else:
+            name = (
+                "main.tf"
+                if "main.tf" not in files
+                else "variables.tf"
+                if "variables.tf" not in files
+                else "outputs.tf"
+            )
+        if name not in files:
+            files[name] = block
+    required = ["main.tf", "variables.tf", "outputs.tf"]
+    for f in required:
+        if f not in files and files:
+            files[f] = "# placeholder\n"
+    return files
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def terraform_generation_scorer() -> Callable:
+    """Scorer for Terraform generation: init + validate only (no LocalStack)."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        # Last assistant message content
+        output = ""
+        for msg in reversed(state.messages):
+            if getattr(msg, "role", None) != "assistant":
+                continue
+            content = getattr(msg, "content", None)
+            if not content:
+                continue
+            if isinstance(content, str):
+                output = content
+            elif hasattr(content, "text"):
+                output = getattr(content, "text", "") or ""
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, str):
+                        output += part
+                    elif getattr(part, "text", None):
+                        output += part.text
+            break
+
+        if not output or not output.strip():
+            return Score(value=0.0, explanation="No model output")
+
+        files = _extract_tf_blocks(output)
+        if not files:
+            return Score(value=0.0, explanation="No Terraform code blocks found")
+
+        with tempfile.TemporaryDirectory(prefix="tfgen_") as tmp:
+            work = Path(tmp)
+            for name, body in files.items():
+                (work / name).write_text(body)
+
+            try:
+                subprocess.run(
+                    ["terraform", "fmt", "-write"],
+                    cwd=work,
+                    capture_output=True,
+                    timeout=30,
+                    check=False,
+                )
+                r = subprocess.run(
+                    ["terraform", "init", "-backend=false"],
+                    cwd=work,
+                    capture_output=True,
+                    timeout=60,
+                    text=True,
+                )
+                if r.returncode != 0:
+                    return Score(
+                        value=0.0,
+                        explanation=(
+                            f"terraform init failed: "
+                            f"{r.stderr[:200] if r.stderr else r.stdout or ''}"
+                        ),
+                    )
+                r = subprocess.run(
+                    ["terraform", "validate"],
+                    cwd=work,
+                    capture_output=True,
+                    timeout=30,
+                    text=True,
+                )
+                if r.returncode != 0:
+                    return Score(
+                        value=0.0,
+                        explanation=(
+                            f"terraform validate failed: "
+                            f"{r.stderr[:200] if r.stderr else r.stdout or ''}"
+                        ),
+                    )
+                return Score(
+                    value=1.0, explanation="terraform init and validate passed"
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                return Score(value=0.0, explanation=str(e))
+
+    return score

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -67,6 +67,22 @@ def test_basic_humaneval():
     assert result.exit_code == 0
 
 
+def test_basic_terraform_generation():
+    """Test basic Terraform generation evaluation (init + validate)."""
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "terraform_generation",
+            "--limit",
+            "1",
+            "--model",
+            "groq/llama-3.1-8b-instant",
+        ],
+    )
+    assert result.exit_code == 0
+
+
 def test_invalid_benchmark():
     """Test invalid benchmark name."""
     result = runner.invoke(

--- a/tests/test_terraform_generation.py
+++ b/tests/test_terraform_generation.py
@@ -1,0 +1,218 @@
+"""Unit tests for Terraform generation dataset, scorer extraction, and scorer scoring."""
+
+import shutil
+from dataclasses import dataclass
+
+import pytest
+
+from openbench.datasets.terraform_generation import (
+    TERRAFORM_PROMPTS,
+    load_dataset,
+)
+from openbench.scorers.terraform_generation import (
+    _extract_tf_blocks,
+    terraform_generation_scorer,
+)
+from inspect_ai.scorer import Target
+
+
+@dataclass
+class MockOutput:
+    completion: str
+
+
+@dataclass
+class MockMessage:
+    role: str
+    content: str
+
+
+@dataclass
+class MockTaskState:
+    messages: list
+    output: MockOutput
+
+
+def _make_state(completion: str, messages: list | None = None) -> MockTaskState:
+    if messages is None:
+        messages = [
+            MockMessage(role="user", content="Generate Terraform"),
+            MockMessage(role="assistant", content=completion),
+        ]
+    out = MockOutput(completion=completion)
+    return MockTaskState(messages=messages, output=out)
+
+
+class TestExtractTfBlocks:
+    """Test _extract_tf_blocks regex extraction."""
+
+    def test_extract_named_blocks(self):
+        """Extract blocks with filename in fence (main.tf, variables.tf, outputs.tf)."""
+        text = """
+**main.tf**
+```main.tf
+resource "aws_vpc" "x" { cidr_block = "10.0.0.0/16" }
+```
+
+```variables.tf
+variable "region" { default = "us-east-1" }
+```
+
+```outputs.tf
+output "vpc_id" { value = aws_vpc.x.id }
+```
+"""
+        files = _extract_tf_blocks(text)
+        assert "main.tf" in files
+        assert "variables.tf" in files
+        assert "outputs.tf" in files
+        assert "aws_vpc" in files["main.tf"]
+        assert "variable" in files["variables.tf"]
+        assert "output" in files["outputs.tf"]
+
+    def test_extract_terraform_lang_block(self):
+        """Single ```terraform block becomes main.tf when no other .tf named."""
+        text = """
+```terraform
+terraform { required_providers { aws = { source = "hashicorp/aws" } } }
+provider "aws" { region = "us-east-1" }
+```
+"""
+        files = _extract_tf_blocks(text)
+        assert "main.tf" in files
+        assert "terraform" in files["main.tf"] or "required_providers" in files["main.tf"]
+        assert "variables.tf" in files  # placeholder
+        assert "outputs.tf" in files  # placeholder
+
+    def test_short_block_ignored(self):
+        """Blocks with very little content are ignored."""
+        text = "```main.tf\nx\n```"
+        files = _extract_tf_blocks(text)
+        # Short block (< 20 chars) is skipped; no other blocks so files is empty
+        assert not files
+
+    def test_no_blocks_empty(self):
+        """No code blocks yields empty dict (no required placeholders if no files)."""
+        files = _extract_tf_blocks("No terraform here at all.")
+        assert not files
+
+    def test_placeholder_for_missing_required(self):
+        """When at least one file is found, missing required files get placeholder."""
+        text = """
+```main.tf
+resource "aws_vpc" "x" { cidr_block = "10.0.0.0/16" }
+```
+"""
+        files = _extract_tf_blocks(text)
+        assert "main.tf" in files
+        assert "variables.tf" in files
+        assert "outputs.tf" in files
+        assert files["variables.tf"] == "# placeholder\n"
+        assert files["outputs.tf"] == "# placeholder\n"
+
+
+class TestLoadDataset:
+    """Test terraform_generation dataset."""
+
+    def test_load_dataset_returns_memory_dataset(self):
+        """load_dataset returns a MemoryDataset."""
+        ds = load_dataset()
+        assert ds is not None
+        assert ds.name == "terraform_generation"
+
+    def test_dataset_has_two_prompts(self):
+        """Dataset has two samples (VPC+EC2 and S3 bucket policy)."""
+        ds = load_dataset()
+        samples = list(ds)
+        assert len(samples) == 2
+        assert samples[0].metadata.get("task_id") == "task_vpc_3subnets_3ec2"
+        assert samples[1].metadata.get("task_id") == "task_s3_bucket_policy"
+
+    def test_prompts_match_config(self):
+        """TERRAFORM_PROMPTS matches dataset task_ids."""
+        assert len(TERRAFORM_PROMPTS) == 2
+        assert TERRAFORM_PROMPTS[0]["task_id"] == "task_vpc_3subnets_3ec2"
+        assert TERRAFORM_PROMPTS[1]["task_id"] == "task_s3_bucket_policy"
+
+
+# Minimal valid Terraform that passes init -backend=false and validate (no apply).
+# Each block goes to one file only to avoid duplicate declarations.
+VALID_MINIMAL_TF = '''
+```main.tf
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 4.0" }
+  }
+}
+provider "aws" {
+  region = "us-east-1"
+}
+```
+```variables.tf
+variable "name" {
+  type    = string
+  default = "test"
+}
+```
+```outputs.tf
+output "out" {
+  value = var.name
+}
+```
+'''
+
+INVALID_TF = '''
+```main.tf
+resource "invalid_syntax" {
+  broken
+```
+'''
+
+
+class TestTerraformGenerationScorer:
+    """Test terraform_generation_scorer with mock state."""
+
+    @pytest.mark.asyncio
+    async def test_no_model_output_returns_zero(self):
+        """Empty or missing assistant message returns 0.0."""
+        # No assistant message -> scorer gets empty output
+        state = _make_state("", messages=[MockMessage(role="user", content="x")])
+        target = Target("pass")
+        scorer_fn = terraform_generation_scorer()
+        result = await scorer_fn(state, target)
+        assert result.value == 0.0
+        assert "No model output" in (result.explanation or "")
+
+    @pytest.mark.asyncio
+    async def test_no_code_blocks_returns_zero(self):
+        """Response with no Terraform code blocks returns 0.0."""
+        state = _make_state("I cannot generate Terraform for this request.")
+        target = Target("pass")
+        scorer_fn = terraform_generation_scorer()
+        result = await scorer_fn(state, target)
+        assert result.value == 0.0
+        assert "No Terraform code blocks" in (result.explanation or "")
+
+    @pytest.mark.asyncio
+    async def test_invalid_terraform_returns_zero(self):
+        """Invalid HCL returns 0.0 (init or validate fails)."""
+        if not shutil.which("terraform"):
+            pytest.skip("terraform CLI not found")
+        state = _make_state(INVALID_TF)
+        target = Target("pass")
+        scorer_fn = terraform_generation_scorer()
+        result = await scorer_fn(state, target)
+        assert result.value == 0.0
+        assert result.explanation
+
+    @pytest.mark.asyncio
+    async def test_valid_minimal_terraform_returns_one(self):
+        """Valid minimal Terraform (init + validate) returns 1.0."""
+        if not shutil.which("terraform"):
+            pytest.skip("terraform CLI not found")
+        state = _make_state(VALID_MINIMAL_TF)
+        target = Target("pass")
+        scorer_fn = terraform_generation_scorer()
+        result = await scorer_fn(state, target)
+        assert result.value == 1.0, result.explanation
+        assert "init and validate passed" in (result.explanation or "")


### PR DESCRIPTION
## Summary

Adds a Terraform Generation benchmark to openbench: the model gets natural-language prompts and must produce Terraform (HCL) for two tasks (VPC + 3 subnets + 3 EC2, and S3 bucket + bucket policy). The scorer extracts .tf code blocks from the model output, runs terraform fmt, terraform init -backend=false, and terraform validate, and scores 1.0 only if init and validate succeed (no plan/apply or LocalStack). Includes dataset, eval, scorer, config entry, registry import, unit tests for extraction/dataset/scorer, and an integration test for bench eval terraform_generation.

## What are you adding?

<!-- Mark with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New benchmark/evaluation
- [ ] New model provider
- [ ] CLI enhancement
- [ ] Performance improvement
- [ ] Documentation update
- [ ] API/SDK feature
- [ ] Integration (CI/CD, tools)
- [ ] Export/import functionality
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Other

## Changes Made

<!-- List the main changes in bullet points -->
- Dataset (src/openbench/datasets/terraform_generation.py): load_dataset() returns a MemoryDataset of 2 samples (VPC+3 subnets+3 EC2, S3 bucket+bucket policy) with prompt text, target="pass", and task_id in metadata.
- Scorer (src/openbench/scorers/terraform_generation.py): terraform_generation_scorer() parses .tf code blocks from the last assistant message, writes them to a temp dir, runs terraform fmt, terraform init -backend=false, and terraform validate; returns Score(1.0) only if init and validate succeed, otherwise Score(0.0) (no plan/apply or LocalStack).
- Eval (src/openbench/evals/terraform_generation.py): @task terraform_generation() builds a Task with the above dataset, solver [generate()], and the custom scorer.
- Config (src/openbench/config.py): Added terraform_generation to _BUILTIN_BENCHMARKS with BenchmarkMetadata (name, description, category, tags, module_path, function_name).
- Registry (src/openbench/_registry.py): Import and re-export of terraform_generation from openbench.evals.terraform_generation.
- Tests (tests/test_terraform_generation.py): Unit tests for _extract_tf_blocks, dataset loading, and scorer (no output, no blocks, invalid Terraform, valid minimal Terraform).
Integration (tests/integration/test_cli.py): test_basic_terraform_generation() runs bench eval terraform_generation --limit 1 with a Groq model.

## Testing

<!-- Describe how you tested your changes -->
- [ ] I have run the existing test suite (`pytest`)
- [x] I have added tests for my changes
- [ ] I have tested with multiple model providers (if applicable)
- [ ] I have run pre-commit hooks (`pre-commit run --all-files`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


