### PR TITLE
fix: quote workdir before shell interpolation to prevent command injection

### DIFF
--- a/src/openbench/agents/aider.py
+++ b/src/openbench/agents/aider.py
@@ -5,6 +5,7 @@ Aider code agent implementation.
 from __future__ import annotations
 
 import os
+import shlex
 from typing import List
 
 from .base import BaseCodeAgent
@@ -46,7 +47,7 @@ class AiderAgent(BaseCodeAgent):
 
             # Create aider execution script
             script_content = get_aider_script_template().format(
-                workdir=workdir, env_setup=env_setup, model=model
+                workdir=shlex.quote(workdir), env_setup=env_setup, model=model
             )
 
             # Execute the script

--- a/src/openbench/agents/gemini.py
+++ b/src/openbench/agents/gemini.py
@@ -5,6 +5,7 @@ Gemini CLI agent implementation.
 from __future__ import annotations
 
 import os
+import shlex
 from typing import List
 
 from .base import BaseCodeAgent
@@ -45,7 +46,7 @@ class GeminiAgent(BaseCodeAgent):
 
             # Create gemini execution script
             script_content = get_gemini_script_template().format(
-                workdir=workdir, env_setup=env_setup, model=model
+                workdir=shlex.quote(workdir), env_setup=env_setup, model=model
             )
 
             # Execute the script

--- a/src/openbench/agents/opencode.py
+++ b/src/openbench/agents/opencode.py
@@ -5,6 +5,7 @@ OpenCode agent implementation.
 from __future__ import annotations
 
 import os
+import shlex
 from typing import List
 
 from .base import BaseCodeAgent
@@ -46,7 +47,7 @@ class OpenCodeAgent(BaseCodeAgent):
 
             # Create opencode execution script
             script_content = get_opencode_script_template().format(
-                workdir=workdir, env_setup=env_setup, model=model
+                workdir=shlex.quote(workdir), env_setup=env_setup, model=model
             )
 
             # Execute the script

--- a/src/openbench/agents/roo.py
+++ b/src/openbench/agents/roo.py
@@ -5,6 +5,7 @@ Roo code agent implementation.
 from __future__ import annotations
 
 import os
+import shlex
 from typing import Dict, List
 
 from .base import BaseCodeAgent
@@ -49,7 +50,7 @@ This will allow the evaluation system to know when you're done."""
 
             # Create roo execution script
             script_content = get_roo_script_template().format(
-                workdir=workdir,
+                workdir=shlex.quote(workdir),
                 env_setup=env_setup,
                 enhanced_prompt=enhanced_prompt,
                 model=model,

--- a/src/openbench/utils/cli_commands.py
+++ b/src/openbench/utils/cli_commands.py
@@ -204,7 +204,7 @@ async def run_setup_commands(setup_commands: List[str], workdir: str) -> str:
     joined = " && ".join(setup_commands)
     try:
         result = await sandbox().exec(
-            cmd=["bash", "-lc", f"cd {workdir} && ({joined})"],
+            cmd=["bash", "-lc", f"cd {shlex.quote(workdir)} && ({joined})"],
             timeout=900,
         )
         parts: List[str] = [
@@ -246,7 +246,7 @@ async def run_final_test(test_command: str, workdir: str) -> str:
             )
 
         result = await sandbox().exec(
-            cmd=["bash", "-lc", f"cd {workdir} && {fixed_test_command}"],
+            cmd=["bash", "-lc", f"cd {shlex.quote(workdir)} && {fixed_test_command}"],
             timeout=600,
         )
         parts: List[str] = [
@@ -573,7 +573,7 @@ def get_roo_script_template() -> str:
 set -eo pipefail
 
 # ========= Environment Setup =========
-export WORKDIR="{workdir}"
+export WORKDIR={workdir}
 export VSCODE_EXT_DIR="/opt/vscode-extensions"
 export VSCODE_USER_DIR="/opt/vscode-user"
 


### PR DESCRIPTION
## Summary

`workdir` is interpolated unquoted into shell commands in two ways:

1. **Direct f-strings** in `cli_commands.py` passed to `bash -lc`:
   ```python
   cmd=["bash", "-lc", f"cd {workdir} && ({joined})"]
   ```

2. **Bash script templates** formatted via `.format(workdir=workdir, ...)` in the agent files — the templates contain `cd {workdir}` and `export WORKDIR="{workdir}"`.

If `workdir` is controlled by a task definition and contains shell metacharacters (e.g. `$(cmd)`, spaces, quotes), arbitrary commands can execute in the sandbox.

`shlex` was already imported in `cli_commands.py` but unused.

## Changes

- `cli_commands.py`: apply `shlex.quote(workdir)` to the two f-string sites; remove double-quotes around `export WORKDIR={workdir}` in the Roo template (so the shell-quoted value isn't double-wrapped)
- `aider.py`, `opencode.py`, `gemini.py`, `roo.py`: add `import shlex` and pass `shlex.quote(workdir)` to `.format()`

## Test plan

- [ ] Verify existing benchmark tasks still resolve workdirs correctly (typical paths like `/tmp/task-abc` are unchanged by `shlex.quote`)
- [ ] Confirm a workdir with spaces (e.g. `/tmp/task name`) is now correctly quoted as `'/tmp/task name'` in the generated script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces command-injection risk in sandboxed `bash -lc` invocations and script templates, but could affect task execution if any downstream scripts relied on unquoted/expanded `workdir` values.
> 
> **Overview**
> **Security hardening:** `workdir` is now shell-quoted (`shlex.quote`) everywhere it is interpolated into `bash -lc` commands and agent-generated script templates (Aider/Gemini/OpenCode/Roo).
> 
> Updates the Roo script template to avoid double-quoting by emitting `export WORKDIR={workdir}` so the pre-quoted value is used verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a80fe8e0ee8a4e7ca3cf31c96cbbb366686fe24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->