### PR TITLE
feat(provider): add Yutori provider support for Navigator model

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ openbench supports 30+ model providers through Inspect AI. Set the appropriate A
 | **Together AI**       | `TOGETHER_API_KEY`     | `together/model-name`            |
 | **Vercel AI Gateway** | `AI_GATEWAY_API_KEY`   | `vercel/creator-name/model-name` |
 | **W&B Inference**     | `WANDB_API_KEY`        | `wandb/model-name`               |
+| **Yutori**            | `YUTORI_API_KEY`       | `yutori/model-name`              |
 | **vLLM**              | None (local)           | `vllm/model-name`                |
 
 ## Available Benchmarks

--- a/docs/providers.mdx
+++ b/docs/providers.mdx
@@ -39,6 +39,7 @@ To access any major model, set the appropriate API key environment variable:
 | **Together AI**       | `TOGETHER_API_KEY`     | `together/model-name`            |
 | **Vercel AI Gateway** | `AI_GATEWAY_API_KEY`   | `vercel/creator-name/model-name` |
 | **W&B Inference**     | `WANDB_API_KEY`        | `wandb/model-name`               |
+| **Yutori**            | `YUTORI_API_KEY`       | `yutori/model-name`              |
 | **vLLM**              | None (local)           | `vllm/model-name`                |
 
 ## Using Unsupported Providers
@@ -138,3 +139,34 @@ bench eval mmlu
     -M only=groq,together 
     -M sort=price 
 ```
+
+### Yutori
+[Yutori](https://yutori.com/) hosts the Navigator computer-use model family. Set your API key:
+```bash
+export YUTORI_API_KEY="yt-..."
+```
+
+**Available Models**
+
+| Model                       | Description                                  |
+|-----------------------------|----------------------------------------------|
+| `yutori/n1.5-latest`        | Navigator n1.5 (recommended, tracks latest)  |
+| `yutori/n1.5-20260428`      | Datestamped Navigator n1.5 snapshot          |
+
+**Navigator-Specific Configuration Options**
+
+Navigator n1.5 accepts a few non-standard request fields, passed via the `-M` flag and forwarded to the API as `extra_body`:
+
+| Parameter              | Description                                                                | Example                                                  |
+|------------------------|----------------------------------------------------------------------------|----------------------------------------------------------|
+| **tool_set**           | Named built-in tool set                                                    | `-M tool_set=browser_tools_expanded-20260403`            |
+| **disable_tools**      | Comma-separated list of tool names to remove from the selected set         | `-M disable_tools=hold_key,drag`                         |
+| **json_schema**        | JSON Schema for structured output (returned as `parsed_json` on response)  | `-M json_schema='{"type":"object","properties":{}}'`     |
+
+```bash
+bench eval path/to/your_browser_eval.py \
+  --model yutori/n1.5-latest \
+  -M tool_set=browser_tools_core-20260403
+```
+
+<Note>Navigator is a screenshot-driven computer-use model — pair it with vision or browser-driven evaluations. Standard text-only benchmarks (MMLU, GPQA, etc.) are not a representative fit.</Note>

--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -195,6 +195,14 @@ def siliconflow() -> Type[ModelAPI]:
     return SiliconFlowAPI
 
 
+@modelapi(name="yutori")
+def yutori() -> Type[ModelAPI]:
+    """Register Yutori provider."""
+    from .model._providers.yutori import YutoriAPI
+
+    return YutoriAPI
+
+
 def _override_builtin_groq_provider():
     """Replace Inspect AI's built-in groq provider with enhanced openbench version."""
     from inspect_ai._util.registry import _registry

--- a/src/openbench/model/_providers/yutori.py
+++ b/src/openbench/model/_providers/yutori.py
@@ -1,0 +1,100 @@
+"""Yutori Navigator provider implementation.
+
+OpenAI-compatible wrapper for the Yutori Navigator Chat Completions API.
+
+Environment variables:
+  - YUTORI_API_KEY: Yutori API key (required)
+  - YUTORI_BASE_URL: Override the default base URL (defaults to
+    https://api.yutori.com/v1)
+
+Example model strings: ``yutori/n1.5-latest``, ``yutori/n1.5-20260428``.
+
+Website: https://yutori.com
+API Docs: https://docs.yutori.com
+"""
+
+import json
+import os
+from typing import Any
+
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+
+
+class YutoriAPI(OpenAICompatibleAPI):
+    """Yutori Navigator provider - OpenAI-compatible Chat Completions."""
+
+    DEFAULT_BASE_URL = "https://api.yutori.com/v1"
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        tool_set: str | None = None,
+        disable_tools: list[str] | str | None = None,
+        json_schema: dict[str, Any] | str | None = None,
+        max_completion_tokens: int | None = None,
+        **model_args: Any,
+    ) -> None:
+        model_name_clean = model_name.replace("yutori/", "", 1)
+        base_url = base_url or os.environ.get("YUTORI_BASE_URL", self.DEFAULT_BASE_URL)
+        api_key = api_key or os.environ.get("YUTORI_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "Yutori API key not found. Set the YUTORI_API_KEY environment variable."
+            )
+
+        # Navigator-specific request fields ride along via extra_body. CLI -M
+        # flags arrive as strings, so coerce list/dict forms here.
+        extras: dict[str, Any] = {}
+        if tool_set is not None:
+            extras["tool_set"] = tool_set
+        if disable_tools is not None:
+            if isinstance(disable_tools, str):
+                disable_tools = [
+                    t.strip() for t in disable_tools.split(",") if t.strip()
+                ]
+            extras["disable_tools"] = disable_tools
+        if json_schema is not None:
+            if isinstance(json_schema, str):
+                try:
+                    json_schema = json.loads(json_schema)
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"Invalid JSON for -M json_schema=...: {e}") from e
+            extras["json_schema"] = json_schema
+        self._extra_body: dict[str, Any] = extras
+        self._max_completion_tokens = max_completion_tokens
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="yutori",
+            service_base_url=self.DEFAULT_BASE_URL,
+            **model_args,
+        )
+
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config=config, tools=tools)
+
+        # Navigator rejects max_tokens; remap so openbench --max-tokens works.
+        # An explicit -M max_completion_tokens=... wins over the remapped value.
+        if "max_tokens" in params:
+            params.setdefault("max_completion_tokens", params.pop("max_tokens"))
+        if self._max_completion_tokens is not None:
+            params["max_completion_tokens"] = self._max_completion_tokens
+
+        # User-supplied extra_body (via GenerateConfig.extra_body) wins over
+        # provider-default Navigator extras from -M flags.
+        if self._extra_body:
+            existing = params.get("extra_body") or {}
+            params["extra_body"] = {**self._extra_body, **existing}
+
+        return params
+
+    def service_model_name(self) -> str:
+        return self.model_name

--- a/src/openbench/provider_config.py
+++ b/src/openbench/provider_config.py
@@ -48,6 +48,7 @@ class ProviderType(str, Enum):
     VERCEL = "vercel"
     WANDB = "wandb"
     XAI = "xai"
+    YUTORI = "yutori"
 
 
 @dataclass
@@ -375,6 +376,15 @@ PROVIDER_CONFIGS: Dict[ProviderType, ProviderConfig] = {
         api_key_env="XAI_API_KEY",
         base_url="https://api.x.ai/v1",
         supports_vision=False,
+        supports_function_calling=True,
+    ),
+    ProviderType.YUTORI: ProviderConfig(
+        name="yutori",
+        display_name="Yutori",
+        api_key_env="YUTORI_API_KEY",
+        base_url="https://api.yutori.com/v1",
+        base_url_env="YUTORI_BASE_URL",
+        supports_vision=True,
         supports_function_calling=True,
     ),
 }

--- a/tests/test_yutori_provider.py
+++ b/tests/test_yutori_provider.py
@@ -1,0 +1,216 @@
+"""Unit tests for the Yutori Navigator provider."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from inspect_ai.model import GenerateConfig
+
+from openbench.model._providers.yutori import YutoriAPI
+from openbench.provider_config import PROVIDER_CONFIGS, ProviderType
+
+
+@pytest.fixture
+def patched_client():
+    """Patch the AsyncOpenAI client so __init__ doesn't need network/credentials."""
+    with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+        yield
+
+
+def _make_api(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> YutoriAPI:
+    """Build a YutoriAPI with sane defaults for tests."""
+    monkeypatch.delenv("YUTORI_BASE_URL", raising=False)
+    kwargs: dict[str, Any] = {
+        "model_name": "yutori/n1.5-latest",
+        "api_key": "test-key",
+    }
+    kwargs.update(overrides)
+    return YutoriAPI(**kwargs)
+
+
+class TestYutoriProviderInit:
+    """Construction-time behavior: prefix stripping, env resolution, errors."""
+
+    def test_strips_yutori_prefix(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch)
+        assert api.service_model_name() == "n1.5-latest"
+
+    def test_reads_api_key_from_env(self, patched_client, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "env-key")
+        api = YutoriAPI(model_name="yutori/n1.5-latest")
+        assert api.api_key == "env-key"
+
+    def test_missing_api_key_raises(self, patched_client, monkeypatch):
+        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="YUTORI_API_KEY"):
+            YutoriAPI(model_name="yutori/n1.5-latest")
+
+    def test_default_base_url(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch)
+        assert api.base_url == "https://api.yutori.com/v1"
+
+    def test_base_url_env_override(self, patched_client, monkeypatch):
+        monkeypatch.setenv("YUTORI_BASE_URL", "https://staging.yutori.com/v1")
+        api = YutoriAPI(model_name="yutori/n1.5-latest", api_key="test-key")
+        assert api.base_url == "https://staging.yutori.com/v1"
+
+    def test_explicit_base_url_wins_over_env(self, patched_client, monkeypatch):
+        monkeypatch.setenv("YUTORI_BASE_URL", "https://staging.yutori.com/v1")
+        api = YutoriAPI(
+            model_name="yutori/n1.5-latest",
+            api_key="test-key",
+            base_url="https://override.yutori.com/v1",
+        )
+        assert api.base_url == "https://override.yutori.com/v1"
+
+
+class TestYutoriCompletionParams:
+    """completion_params() must remap max_tokens and inject Navigator extras."""
+
+    def test_max_tokens_remapped(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch)
+        params = api.completion_params(GenerateConfig(max_tokens=512), tools=False)
+        assert "max_tokens" not in params
+        assert params["max_completion_tokens"] == 512
+
+    def test_no_remap_when_max_tokens_unset(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch)
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert "max_tokens" not in params
+        # No spurious max_completion_tokens injection either.
+        assert "max_completion_tokens" not in params
+
+    def test_tool_set_in_extra_body(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch, tool_set="browser_tools_expanded-20260403")
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["tool_set"] == "browser_tools_expanded-20260403"
+
+    def test_disable_tools_string_parsed_to_list(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch, disable_tools="hold_key, drag ,  ")
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["disable_tools"] == ["hold_key", "drag"]
+
+    def test_disable_tools_list_passthrough(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch, disable_tools=["hold_key", "drag"])
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["disable_tools"] == ["hold_key", "drag"]
+
+    def test_json_schema_string_parsed(self, patched_client, monkeypatch):
+        schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        api = _make_api(monkeypatch, json_schema=json.dumps(schema))
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["json_schema"] == schema
+
+    def test_json_schema_dict_passthrough(self, patched_client, monkeypatch):
+        schema = {"type": "object"}
+        api = _make_api(monkeypatch, json_schema=schema)
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["json_schema"] == schema
+
+    def test_no_extra_body_when_no_extras(self, patched_client, monkeypatch):
+        api = _make_api(monkeypatch)
+        params = api.completion_params(GenerateConfig(), tools=False)
+        # Either the key is absent or the value is falsy — both acceptable.
+        assert not params.get("extra_body")
+
+    def test_user_extra_body_wins_over_provider_defaults(
+        self, patched_client, monkeypatch
+    ):
+        """A caller's GenerateConfig.extra_body overrides Navigator defaults on key collision."""
+        api = _make_api(monkeypatch, tool_set="provider-default")
+        # Simulate the base class returning an existing extra_body — happens when
+        # a caller sets GenerateConfig.extra_body explicitly.
+        original = api.completion_params
+
+        def with_existing(config, tools):
+            params = original(GenerateConfig(), tools=tools)
+            return params
+
+        # Monkeypatch the parent's completion_params to inject extra_body.
+        from inspect_ai.model._providers import openai_compatible
+
+        def fake_parent(self, config, tools):
+            return {"extra_body": {"tool_set": "user-wins", "user_only": 1}}
+
+        monkeypatch.setattr(
+            openai_compatible.OpenAICompatibleAPI,
+            "completion_params",
+            fake_parent,
+        )
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert params["extra_body"]["tool_set"] == "user-wins"
+        assert params["extra_body"]["user_only"] == 1
+
+    def test_explicit_max_completion_tokens_wins_over_remap(
+        self, patched_client, monkeypatch
+    ):
+        """If both max_tokens and max_completion_tokens are set, the explicit one wins."""
+        from inspect_ai.model._providers import openai_compatible
+
+        def fake_parent(self, config, tools):
+            return {"max_tokens": 100, "max_completion_tokens": 500}
+
+        monkeypatch.setattr(
+            openai_compatible.OpenAICompatibleAPI,
+            "completion_params",
+            fake_parent,
+        )
+        api = _make_api(monkeypatch)
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert "max_tokens" not in params
+        assert params["max_completion_tokens"] == 500
+
+    def test_invalid_json_schema_raises_actionable_error(
+        self, patched_client, monkeypatch
+    ):
+        """A malformed -M json_schema=... fails loud-and-early with provider context."""
+        with pytest.raises(ValueError, match="json_schema"):
+            _make_api(monkeypatch, json_schema="{not valid json")
+
+    def test_max_completion_tokens_kwarg_not_passed_to_async_openai(
+        self, patched_client, monkeypatch
+    ):
+        """Regression: -M max_completion_tokens=N must not leak into AsyncOpenAI kwargs."""
+        api = _make_api(monkeypatch, max_completion_tokens=500)
+        assert "max_completion_tokens" not in api.model_args
+
+    def test_explicit_max_completion_tokens_kwarg_wins_over_remap(
+        self, patched_client, monkeypatch
+    ):
+        """An explicit -M max_completion_tokens=N overrides the --max-tokens remap."""
+        from inspect_ai.model._providers import openai_compatible
+
+        def fake_parent(self, config, tools):
+            return {"max_tokens": 100}
+
+        monkeypatch.setattr(
+            openai_compatible.OpenAICompatibleAPI,
+            "completion_params",
+            fake_parent,
+        )
+        api = _make_api(monkeypatch, max_completion_tokens=500)
+        params = api.completion_params(GenerateConfig(), tools=False)
+        assert "max_tokens" not in params
+        assert params["max_completion_tokens"] == 500
+
+
+class TestYutoriProviderConfig:
+    """The provider must be wired into the centralized PROVIDER_CONFIGS table."""
+
+    def test_provider_config_registered(self):
+        config = PROVIDER_CONFIGS[ProviderType.YUTORI]
+        assert config.name == "yutori"
+        assert config.api_key_env == "YUTORI_API_KEY"
+        assert config.base_url_env == "YUTORI_BASE_URL"
+        assert config.base_url == "https://api.yutori.com/v1"
+        assert config.supports_vision is True
+        assert config.supports_function_calling is True
+
+    def test_env_vars_listed(self):
+        config = PROVIDER_CONFIGS[ProviderType.YUTORI]
+        env_vars = config.get_all_env_vars()
+        assert "YUTORI_API_KEY" in env_vars
+        assert "YUTORI_BASE_URL" in env_vars


### PR DESCRIPTION
## Summary

Adds [Yutori](https://yutori.com/) as a model provider so openbench can target Yutori's [Navigator](https://docs.yutori.com) computer-use model family. The Navigator API is OpenAI-compatible Chat Completions, so the new `YutoriAPI` plugs into Inspect AI's standard `OpenAICompatibleAPI` machinery — same pattern as Baseten, SiliconFlow, etc.; closely modeled on #269.

Navigator is a screenshot-driven vision/computer-use model, not a text reasoner. This PR is just the provider plumbing — the natural pairing is a browser-use or vision benchmark (bring your own with `bench eval path/to/eval.py`, or wait for a future built-in).

## What are you adding?

- [x] New model provider

## Changes Made

- New `YutoriAPI(OpenAICompatibleAPI)` in `src/openbench/model/_providers/yutori.py`.
- `@modelapi(name="yutori")` registration in `_registry.py`; `ProviderType.YUTORI` + entry in `PROVIDER_CONFIGS`.
- Provider row in `README.md`; provider row + "Yutori-Specific Configuration Options" subsection in `docs/providers.mdx`.
- 21 unit tests in `tests/test_yutori_provider.py`.

### Navigator-specific behavior in the provider

- Navigator's Chat Completions API uses `max_completion_tokens` (the modern OpenAI Chat Completions field) and rejects `max_tokens`. The provider's `completion_params()` silently remaps openbench's `--max-tokens` flag onto `max_completion_tokens` so callers don't need to know about the rename. An explicit `-M max_completion_tokens=N` wins over the remapped value.
- A few Navigator-only request fields are exposed as `-M` kwargs and forwarded as `extra_body`: `tool_set`, `disable_tools`, `json_schema` (matching the public [Yutori SDK](https://github.com/yutori-ai/yutori-sdk-python) surface).

## Testing

- [x] `pytest tests/test_yutori_provider.py` — 21 passed
- [x] `pytest` — full non-integration suite passing
- [x] `pre-commit run --all-files` — ruff, mypy, registry-imports all green
- [x] Smoke-tested: `inspect_ai.get_model("yutori/n1.5-latest")` resolves to `YutoriAPI`, picks up `YUTORI_API_KEY` and `YUTORI_BASE_URL` overrides correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes