### PR TITLE
Update copyright to 'Groq LLC' and bump year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2025 Groq, Inc.
+Copyright (c) 2026 Groq LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## Branding / legal-name cleanup
Updates the copyright notice to the current legal entity **`Groq LLC`** and bumps the year to **2026**.
```
- Copyright (c) 2025 Groq, Inc.
+ Copyright (c) 2026 Groq LLC
```
File changed:
- `LICENSE.md`
Scope: copyright / branding text only. (Canary PR — part of a cross-repo cleanup; the remaining repos will follow the same pattern: legal-entity `Groq LLC` + year `2026`.)