### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/openbench/_registry.py
+++ b/src/openbench/_registry.py
@@ -107,6 +107,14 @@ def deepinfra() -> Type[ModelAPI]:
     return DeepInfraAPI
 
 
+@modelapi(name="litellm")
+def litellm() -> Type[ModelAPI]:
+    """Register LiteLLM AI gateway provider."""
+    from .model._providers.litellm import LiteLLMAPI
+
+    return LiteLLMAPI
+
+
 @modelapi(name="ai21")
 def ai21() -> Type[ModelAPI]:
     """Register AI21 Labs provider."""

--- a/src/openbench/model/_providers/litellm.py
+++ b/src/openbench/model/_providers/litellm.py
@@ -1,0 +1,50 @@
+"""LiteLLM AI gateway provider implementation."""
+
+import os
+from typing import Any
+
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model import GenerateConfig
+
+
+class LiteLLMAPI(OpenAICompatibleAPI):
+    """LiteLLM AI gateway provider - access 100+ LLM providers through one interface.
+
+    Uses OpenAI-compatible API pointed at a LiteLLM proxy. The model name
+    is passed through as-is, so use whatever model identifiers your LiteLLM
+    config defines (e.g. ``litellm/anthropic/claude-sonnet-4-6``).
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        model_name_clean = model_name.replace("litellm/", "", 1)
+
+        base_url = base_url or os.environ.get(
+            "LITELLM_BASE_URL", "http://localhost:4000/v1"
+        )
+        api_key = api_key or os.environ.get("LITELLM_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "LiteLLM API key not found. Set LITELLM_API_KEY environment variable."
+            )
+
+        super().__init__(
+            model_name=model_name_clean,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="litellm",
+            service_base_url="http://localhost:4000/v1",
+            **model_args,
+        )
+
+    def service_model_name(self) -> str:
+        """Return model name without service prefix."""
+        return self.model_name

--- a/src/openbench/provider_config.py
+++ b/src/openbench/provider_config.py
@@ -31,6 +31,7 @@ class ProviderType(str, Enum):
     HUGGINGFACE = "huggingface"
     HYPERBOLIC = "hyperbolic"
     LAMBDA = "lambda"
+    LITELLM = "litellm"
     MINIMAX = "minimax"
     MISTRAL = "mistral"
     MOONSHOT = "moonshot"
@@ -230,6 +231,15 @@ PROVIDER_CONFIGS: Dict[ProviderType, ProviderConfig] = {
         api_key_env="LAMBDA_API_KEY",
         base_url="https://api.lambdalabs.com/v1",
         supports_vision=False,
+        supports_function_calling=True,
+    ),
+    ProviderType.LITELLM: ProviderConfig(
+        name="litellm",
+        display_name="LiteLLM AI Gateway",
+        api_key_env="LITELLM_API_KEY",
+        base_url="http://localhost:4000/v1",
+        base_url_env="LITELLM_BASE_URL",
+        supports_vision=True,
         supports_function_calling=True,
     ),
     ProviderType.MINIMAX: ProviderConfig(

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,81 @@
+"""Unit tests for LiteLLM AI gateway provider."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from openbench.model._providers.litellm import LiteLLMAPI
+
+
+class TestLiteLLMProvider:
+    """Test LiteLLM provider initialization and configuration."""
+
+    def test_raises_without_api_key(self):
+        """Provider raises ValueError when no API key is available."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="LITELLM_API_KEY"):
+                with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                    LiteLLMAPI(model_name="litellm/gpt-4o")
+
+    def test_strips_service_prefix_from_model_name(self):
+        """The litellm/ prefix is stripped before passing to the base class."""
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-test"}):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(
+                    model_name="litellm/anthropic/claude-sonnet-4-6",
+                    api_key="sk-test",
+                    base_url="http://localhost:4000/v1",
+                )
+                assert provider.model_name == "anthropic/claude-sonnet-4-6"
+
+    def test_uses_env_api_key(self):
+        """Provider reads LITELLM_API_KEY from environment."""
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-from-env"}):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(
+                    model_name="litellm/gpt-4o",
+                    base_url="http://localhost:4000/v1",
+                )
+                assert provider.api_key == "sk-from-env"
+
+    def test_explicit_api_key_overrides_env(self):
+        """Explicit api_key parameter takes precedence over env var."""
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-from-env"}):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(
+                    model_name="litellm/gpt-4o",
+                    api_key="sk-explicit",
+                    base_url="http://localhost:4000/v1",
+                )
+                assert provider.api_key == "sk-explicit"
+
+    def test_default_base_url(self):
+        """Provider defaults to localhost:4000 when no base URL is set."""
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-test"}, clear=True):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(model_name="litellm/gpt-4o")
+                assert provider.base_url == "http://localhost:4000/v1"
+
+    def test_custom_base_url_from_env(self):
+        """Provider reads LITELLM_BASE_URL from environment."""
+        with patch.dict(
+            os.environ,
+            {
+                "LITELLM_API_KEY": "sk-test",
+                "LITELLM_BASE_URL": "https://proxy.example.com/v1",
+            },
+        ):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(model_name="litellm/gpt-4o")
+                assert provider.base_url == "https://proxy.example.com/v1"
+
+    def test_service_model_name_returns_clean_name(self):
+        """service_model_name() returns the model name without prefix."""
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-test"}):
+            with patch("inspect_ai.model._providers.openai_compatible.AsyncOpenAI"):
+                provider = LiteLLMAPI(
+                    model_name="litellm/openai/gpt-4o",
+                    base_url="http://localhost:4000/v1",
+                )
+                assert provider.service_model_name() == "openai/gpt-4o"


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://litellm.ai) as a model provider, enabling benchmarks to run against 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, etc.) through a single LiteLLM proxy endpoint.

## What are you adding?

- [x] New model provider

## Changes Made

- `src/openbench/model/_providers/litellm.py` - New `LiteLLMAPI` class extending `OpenAICompatibleAPI` (follows the exact `DeepInfraAPI` pattern)
- `src/openbench/_registry.py` - Registered `litellm` provider via `@modelapi` decorator
- `src/openbench/provider_config.py` - Added `LITELLM` to `ProviderType` enum and `PROVIDER_CONFIGS`
- `tests/test_litellm_provider.py` - 7 unit tests covering initialization, API key handling, URL config, model name stripping

## Testing

- [x] I have run the existing test suite (`pytest`)
- [x] I have added tests for my changes
- [x] I have tested with multiple model providers (if applicable)
- [x] I have run pre-commit hooks (`pre-commit run --all-files`)

```
tests/test_litellm_provider.py .......    7 passed
Full suite: 395 passed, 10 skipped in 60.73s
ruff format -> unchanged
ruff check -> All checks passed!
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context

### Usage

1. Start a LiteLLM proxy with your providers:

```yaml
# litellm_config.yaml
model_list:
  - model_name: anthropic/claude-sonnet-4-6
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_key: sk-ant-...
  - model_name: openai/gpt-4o
    litellm_params:
      model: gpt-4o
      api_key: sk-...

litellm_settings:
  drop_params: true
```

```bash
pip install litellm
litellm --config litellm_config.yaml --port 4000
```

2. Run benchmarks through LiteLLM:

```bash
export LITELLM_API_KEY=sk-...
export LITELLM_BASE_URL=http://localhost:4000/v1

# Evaluate Claude via LiteLLM proxy
bench eval mmlu --model litellm/anthropic/claude-sonnet-4-6 --limit 10

# Evaluate GPT-4o via same proxy
bench eval mmlu --model litellm/openai/gpt-4o --limit 10

# Any model your proxy serves
bench eval humaneval --model litellm/groq/llama-3.3-70b-versatile --limit 5
```

3. Or use programmatically:

```python
from openbench.model._providers.litellm import LiteLLMAPI
from inspect_ai.model import GenerateConfig

provider = LiteLLMAPI(
    model_name="litellm/anthropic/claude-sonnet-4-6",
    api_key="sk-your-litellm-key",
    base_url="http://localhost:4000/v1",
    config=GenerateConfig(temperature=0.0, max_tokens=1024),
)
```

The model name after `litellm/` is passed directly to the proxy, so use whatever model identifiers your LiteLLM config defines. No new dependencies required since the provider uses the existing `OpenAICompatibleAPI` base class from inspect-ai.