### PR TITLE
Add Andrew Tan and James Franco as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AarushSah @nmayorga7
+* @AarushSah @nmayorga7 @andrewtlw @BetterWithBeyti


### PR DESCRIPTION
Adds @andrewtlw and @BetterWithBeyti to the catch-all CODEOWNERS rule so they are requested for review on all changes.

Both are members of the groq org with access to this repo (write and admin, respectively), so the entries are valid code owners.