### PR TITLE
ci: raise the claude review turn limit to 30

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
           
           claude_args: |
             --model claude-opus-5
-            --max-turns 10
+            --max-turns 30
           
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## TL;DR

`--max-turns 10` can exhaust before the Claude review posts findings. Raised to 30, in line with the other review workflows in the org.

## Summary

`gitops-infra` runs the same action at 10 and failed on a 19-file PR with `"subtype": "error_max_turns"`. The budget scales with the number of files the review has to read, not with the size of the diff, since the action reads files individually rather than taking one `git diff`.

This workflow has no `track_progress`, so it is not spending turns on comment updates, but 10 is still the lowest ceiling in the org. `observability` uses 30, `gkms` 50, and `neocloud-controllers` 20.

## Test plan

Open or re-run a review on a multi-file PR and confirm it posts findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)